### PR TITLE
Added a flag specifying datacenter(s) to launch instances

### DIFF
--- a/cmd/clusterAddWorker.go
+++ b/cmd/clusterAddWorker.go
@@ -63,6 +63,7 @@ You can specify the worker server type as in cluster create.`,
 		name, _ := cmd.Flags().GetString("name")
 		_, cluster := AppConf.Config.FindClusterByName(name)
 		workerServerType, _ := cmd.Flags().GetString("worker-server-type")
+		datacenters, _ := cmd.Flags().GetStringSlice("datacenters")
 		var sshKeyName string
 
 		for _, node := range cluster.Nodes {
@@ -95,7 +96,7 @@ You can specify the worker server type as in cluster create.`,
 
 		cluster.coordinator = pkg.NewProgressCoordinator()
 
-		nodes, err := cluster.CreateWorkerNodes(sshKeyName, workerServerType, nodeCount, maxNo)
+		nodes, err := cluster.CreateWorkerNodes(sshKeyName, workerServerType, datacenters, nodeCount, maxNo)
 
 		FatalOnError(err)
 
@@ -118,4 +119,5 @@ func init() {
 	clusterAddWorkerCmd.Flags().StringP("name", "", "", "Name of the cluster to add the workers to")
 	clusterAddWorkerCmd.Flags().String("worker-server-type", "cx11", "Server type used of workers")
 	clusterAddWorkerCmd.Flags().IntP("nodes", "n", 2, "Number of nodes for the cluster")
+	clusterAddWorkerCmd.Flags().StringSlice("datacenters", []string{"nbg1-dc3", "fsn1-dc8"}, "Can be used to filter datacenters by their name")
 }

--- a/cmd/clusterCreate.go
+++ b/cmd/clusterCreate.go
@@ -48,6 +48,7 @@ to quickly create a Cobra application.`,
 		sshKeyName, _ := cmd.Flags().GetString("ssh-key")
 		masterServerType, _ := cmd.Flags().GetString("master-server-type")
 		workerServerType, _ := cmd.Flags().GetString("worker-server-type")
+		datacenters, _ := cmd.Flags().GetStringSlice("datacenters")
 
 		err := capturePassphrase(sshKeyName)
 
@@ -61,14 +62,14 @@ to quickly create a Cobra application.`,
 			cluster.CloudInitFile = cloudInit
 		}
 
-		if err := cluster.CreateMasterNodes(sshKeyName, masterServerType, 1); err != nil {
+		if err := cluster.CreateMasterNodes(sshKeyName, masterServerType, datacenters, 1); err != nil {
 			log.Println(err)
 		}
 
 		var nodes []Node
 		if workerCount > 0 {
 			var err error
-			nodes, err = cluster.CreateWorkerNodes(sshKeyName, workerServerType, workerCount, 0)
+			nodes, err = cluster.CreateWorkerNodes(sshKeyName, workerServerType, datacenters, workerCount, 0)
 			FatalOnError(err)
 		}
 
@@ -182,5 +183,5 @@ func init() {
 	clusterCreateCmd.Flags().Bool("self-hosted", false, "If true, the kubernetes control plane will be hosted on itself")
 	clusterCreateCmd.Flags().IntP("nodes", "n", 2, "Number of nodes for the cluster")
 	clusterCreateCmd.Flags().StringP("cloud-init", "", "", "Cloud-init file for server preconfiguration")
-
+	clusterCreateCmd.Flags().StringSlice("datacenters", []string{"nbg1-dc3", "fsn1-dc8"}, "Can be used to filter datacenters by their name")
 }


### PR DESCRIPTION
Added flag `--datacenters strings (default [nbg1-dc3,fsn1-dc8])` to `hetzner-kube cluster create` and `hetzner-kube cluster add-worker` commands

Example:

```bash
$ hetzner-kube cluster create --name test --nodes 5 --datacenters nbg1-dc3,fsn1-dc8 --ssh-key macbook-pro-key
```

Result:

![server hetzner cloud 2018-02-22 12-13-48](https://user-images.githubusercontent.com/11014184/36529682-1adab5de-17ca-11e8-967f-863b6cd400d0.png)