### PR TITLE
fix: send "complete!" event if etcd is deployed isolated

### DIFF
--- a/cmd/clusterCreate.go
+++ b/cmd/clusterCreate.go
@@ -130,7 +130,7 @@ This tool supports these levels of kubernetes HA:
 				etcdNodes = cluster.GetMasterNodes()
 			}
 
-			err = cluster.InstallEtcdNodes(etcdNodes)
+			err = cluster.InstallEtcdNodes(etcdNodes, isolatedEtcd)
 			FatalOnError(err)
 
 			saveCluster(&cluster)

--- a/cmd/nodeUtil.go
+++ b/cmd/nodeUtil.go
@@ -393,7 +393,7 @@ func (cluster *Cluster) installMasterStep(node Node, numMaster int, masterNode N
 	trueChan <- true
 }
 
-func (cluster *Cluster) InstallEtcdNodes(nodes []Node) error {
+func (cluster *Cluster) InstallEtcdNodes(nodes []Node, isolatedEtcd bool) error {
 
 	commands := []SSHCommand{
 		{"download etcd", "mkdir -p /opt/etcd && curl -L https://storage.googleapis.com/etcd/v3.2.13/etcd-v3.2.13-linux-amd64.tar.gz -o /opt/etcd-v3.2.13-linux-amd64.tar.gz"},
@@ -423,7 +423,11 @@ func (cluster *Cluster) InstallEtcdNodes(nodes []Node) error {
 					errChan <- err
 				}
 			}
-			cluster.coordinator.AddEvent(node.Name, "etcd configured")
+			if isolatedEtcd {
+				cluster.coordinator.AddEvent(node.Name, "complete!")
+			} else {
+				cluster.coordinator.AddEvent(node.Name, "etcd configured")
+			}
 			trueChan <- true
 		}(node)
 	}


### PR DESCRIPTION
If etcd is deployed on isolated nodes we have to return a "complete!"
event so the deployment process finish succesfully

closes #24