### PR TITLE
refactor: make complete event more robust

### DIFF
--- a/cmd/nodeUtil.go
+++ b/cmd/nodeUtil.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"errors"
 	"time"
+	"github.com/xetys/hetzner-kube/pkg"
 )
 
 func (cluster *Cluster) CreateNodes(suffix string, template Node, datacenters []string, count int, offset int) ([]Node, error) {
@@ -387,7 +388,7 @@ func (cluster *Cluster) installMasterStep(node Node, numMaster int, masterNode N
 	}
 
 	if !cluster.HaEnabled {
-		cluster.coordinator.AddEvent(node.Name, "complete!")
+		cluster.coordinator.AddEvent(node.Name, pkg.CompletedEvent)
 	}
 
 	trueChan <- true
@@ -424,7 +425,7 @@ func (cluster *Cluster) InstallEtcdNodes(nodes []Node, isolatedEtcd bool) error 
 				}
 			}
 			if isolatedEtcd {
-				cluster.coordinator.AddEvent(node.Name, "complete!")
+				cluster.coordinator.AddEvent(node.Name, pkg.CompletedEvent)
 			} else {
 				cluster.coordinator.AddEvent(node.Name, "etcd configured")
 			}
@@ -487,7 +488,7 @@ func (cluster *Cluster) InstallWorkers(nodes []Node) error {
 				}
 			}
 
-			cluster.coordinator.AddEvent(node.Name, "complete!")
+			cluster.coordinator.AddEvent(node.Name, pkg.CompletedEvent)
 		}
 	}
 
@@ -551,7 +552,7 @@ func (cluster *Cluster) SetupHA() error {
 			// wait for the apiserver to be back online
 			cluster.coordinator.AddEvent(node.Name, "wait for apiserver")
 			_, err = runCmd(node, `until $(kubectl get node > /dev/null 2>/dev/null ); do echo "wait.."; sleep 1; done`)
-			cluster.coordinator.AddEvent(node.Name, "complete!")
+			cluster.coordinator.AddEvent(node.Name, pkg.CompletedEvent)
 
 			trueChan <- true
 		}(node)

--- a/pkg/progress_coordinator.go
+++ b/pkg/progress_coordinator.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 )
 
+const CompletedEvent = "complete!"
+
 type ProgressCoordinator struct {
 	group      sync.WaitGroup
 	progresses map[string]*Progress
@@ -54,7 +56,7 @@ func (c *ProgressCoordinator) StartProgress(name string, steps int) {
 				fmt.Printf("%s: %s (%d)", progress.Name, event, progress.Bar.Current()+1)
 				fmt.Println()
 			}
-			if event == "complete!" {
+			if event == CompletedEvent {
 				progress.Bar.Set(progress.Bar.Total)
 				progress.SetText(event)
 				break


### PR DESCRIPTION
The string for the complete event should be wrapped in a constant as changes may break the system otherwise.