### PR TITLE
Add a dependency on linux-headers-virtual

### DIFF
--- a/install-docker-kubeadm.sh
+++ b/install-docker-kubeadm.sh
@@ -32,7 +32,7 @@ EOF
 add-apt-repository ppa:wireguard/wireguard -y
 
 apt-get update && apt-get install -y docker-ce
-apt-get install -y docker-ce kubelet kubeadm kubectl wireguard linux-headers-$(uname -r)
+apt-get install -y docker-ce kubelet kubeadm kubectl wireguard linux-headers-$(uname -r) linux-headers-virtual
 
 # prepare for hetzners cloud controller manager
 mkdir -p /etc/systemd/system/kubelet.service.d


### PR DESCRIPTION
As the kernel is provided implicitly by linux-image-virtual, if linux-headers-virtual isn't also installed then any future kernel upgrade will leave the system without headers for DKMS, breaking wireguard. The linux-headers-$(uname -r) version is also needed, as otherwise there won't be headers for the *running* system, necessitating an upgrade and reboot at this step.

Tested: No. I figured this out by manually poking at apt-get and resolving precisely that wireguard problem.