### PR TITLE
Fix PR-37 external hcloud manager

### DIFF
--- a/cmd/clusterAddExternalWorker.go
+++ b/cmd/clusterAddExternalWorker.go
@@ -15,12 +15,12 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"errors"
 	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/xetys/hetzner-kube/pkg"
 	"log"
 	"strings"
-	"github.com/xetys/hetzner-kube/pkg"
 )
 
 // clusterAddWorkerCmd represents the clusterAddWorker command
@@ -60,8 +60,9 @@ An external server must meet the following requirements:
 		}
 
 		externalNode := Node{
-			IPAddress: ipAddress,
+			IPAddress:  ipAddress,
 			SSHKeyName: cluster.Nodes[0].SSHKeyName,
+			IsExternal: true,
 		}
 
 		sshKeyName := cluster.Nodes[0].SSHKeyName
@@ -93,7 +94,6 @@ An external server must meet the following requirements:
 			return errors.New("target server has no Ubuntu 16.04 installed")
 		}
 
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -119,8 +119,9 @@ An external server must meet the following requirements:
 		}
 
 		externalNode := Node{
-			IPAddress: ipAddress,
+			IPAddress:  ipAddress,
 			SSHKeyName: sshKeyName,
+			IsExternal: true,
 		}
 
 		hostname, err := runCmd(externalNode, "hostname -s")
@@ -130,7 +131,7 @@ An external server must meet the following requirements:
 
 		// render internal IP address
 		nextNode := 21
-		for _,node := range cluster.Nodes {
+		for _, node := range cluster.Nodes {
 			if !node.IsMaster && !node.IsEtcd {
 				nextNode++
 			}
@@ -154,7 +155,6 @@ An external server must meet the following requirements:
 		err = cluster.SetupEncryptedNetwork()
 		FatalOnError(err)
 		saveCluster(cluster)
-
 
 		if cluster.HaEnabled {
 			err = cluster.DeployLoadBalancer(nodes)

--- a/cmd/clusterAddExternalWorker.go
+++ b/cmd/clusterAddExternalWorker.go
@@ -143,6 +143,8 @@ An external server must meet the following requirements:
 
 		FatalOnError(err)
 
+		cluster.Nodes = append(cluster.Nodes, externalNode)
+
 		cluster.RenderProgressBars(nodes)
 		err = cluster.ProvisionNodes(nodes)
 		FatalOnError(err)

--- a/cmd/nodeUtil.go
+++ b/cmd/nodeUtil.go
@@ -88,6 +88,8 @@ func (cluster *Cluster) CreateNodes(suffix string, template Node, datacenters []
 }
 
 func (cluster *Cluster) ProvisionNodes(nodes []Node) error {
+	nodes = cluster.Nodes
+
 	errChan := make(chan error)
 	trueChan := make(chan bool)
 	numProcs := 0

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -21,6 +21,7 @@ type Node struct {
 	Name             string    `json:"name"`
 	Type             string    `json:"type"`
 	IsMaster         bool      `json:"is_master"`
+	IsExternal       bool      `json:"is_external"`
 	IsEtcd           bool      `json:"is_etcd"`
 	IPAddress        string    `json:"ip_address"`
 	PrivateIPAddress string    `json:"private_ip_address"`

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -21,11 +21,11 @@ type Node struct {
 	Name             string    `json:"name"`
 	Type             string    `json:"type"`
 	IsMaster         bool      `json:"is_master"`
-	IsExternal       bool      `json:"is_external"`
 	IsEtcd           bool      `json:"is_etcd"`
 	IPAddress        string    `json:"ip_address"`
 	PrivateIPAddress string    `json:"private_ip_address"`
 	SSHKeyName       string    `json:"ssh_key_name"`
+	SSHPort          string    `json:"ssh_port"`
 	WireGuardKeyPair WgKeyPair `json:"wire_guard_key_pair"`
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,24 +3,24 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"github.com/Pallinder/go-randomdata"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"log"
-	"time"
-	"github.com/Pallinder/go-randomdata"
-	"encoding/pem"
-	"strings"
-	"golang.org/x/crypto/ssh/terminal"
-	"syscall"
 	"path"
+	"strings"
+	"syscall"
+	"time"
 )
 
 var sshPassPhrases = make(map[string][]byte)
 
-func capturePassphrase(sshKeyName string) (error) {
+func capturePassphrase(sshKeyName string) error {
 	index, privateKey := AppConf.Config.FindSSHKeyByName(sshKeyName)
 	if index < 0 {
 		return errors.New(fmt.Sprintf("could not find SSH key '%s'", sshKeyName))
@@ -124,8 +124,12 @@ func writeNodeFile(node Node, filePath string, content string, executable bool) 
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	var connection *ssh.Client
+	sshPort := "22"
+	if node.SSHPort != "" {
+		sshPort = node.SSHPort
+	}
 	for try := 0; ; try++ {
-		connection, err = ssh.Dial("tcp", node.IPAddress+":22", config)
+		connection, err = ssh.Dial("tcp", node.IPAddress+":"+sshPort, config)
 		if err != nil {
 			log.Printf("dial failed:%v", err)
 			if try > 10 {
@@ -154,7 +158,7 @@ func writeNodeFile(node Node, filePath string, content string, executable bool) 
 	session.Stderr = &stderrBuf
 
 	go func() {
-		w,_ := session.StdinPipe()
+		w, _ := session.StdinPipe()
 		defer w.Close()
 		fmt.Fprintln(w, permission, len(content), fileName)
 		fmt.Fprint(w, content)
@@ -172,7 +176,7 @@ func writeNodeFile(node Node, filePath string, content string, executable bool) 
 
 func copyFileOverNode(sourceNode Node, targetNode Node, filePath string, manipulator func(string) string) error {
 	// get the file
-	fileContent, err := runCmd(sourceNode, "cat " + filePath)
+	fileContent, err := runCmd(sourceNode, "cat "+filePath)
 	if err != nil {
 		return err
 	}
@@ -199,8 +203,12 @@ func runCmd(node Node, command string) (output string, err error) {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	var connection *ssh.Client
+	sshPort := "22"
+	if node.SSHPort != "" {
+		sshPort = node.SSHPort
+	}
 	for try := 0; ; try++ {
-		connection, err = ssh.Dial("tcp", node.IPAddress+":22", config)
+		connection, err = ssh.Dial("tcp", node.IPAddress+":"+sshPort, config)
 		if err != nil {
 			log.Printf("dial failed:%v", err)
 			if try > 10 {
@@ -223,7 +231,7 @@ func runCmd(node Node, command string) (output string, err error) {
 	session.Stderr = &stderrBuf
 
 	err = session.Run(command)
-	
+
 	if err != nil {
 		log.Println(stderrBuf.String())
 		log.Printf("> %s", command)


### PR DESCRIPTION
Quick fix to just remove the extra flag `--cloud-provider=external` on provisioning external node.
Not fully tested right now as the build is broken, see #38 