### PR TITLE
Addon cert manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You can install some addons to your cluster using the `cluster addon` sub-comman
 * [Rook](https://rook.io)
 * OpenEBS
 * NGinx ingress controller (requires helm)
+* [cert-manager](https://github.com/jetstack/cert-manager) (requires helm)
 
 ### contributing new addons
 

--- a/cmd/addon_cert-manager.go
+++ b/cmd/addon_cert-manager.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "log"
+
+type CertmanagerAddon struct {
+	masterNode *Node
+}
+
+func NewCertmanagerAddon(cluster Cluster) ClusterAddon {
+	masterNode, err := cluster.GetMasterNode()
+	FatalOnError(err)
+	return CertmanagerAddon{masterNode: masterNode}
+}
+
+func (addon CertmanagerAddon) Install(args ... string) {
+	node := *addon.masterNode
+	_, err := runCmd(node, "helm install --name cert-manager --namespace kube-system --set ingressShim.extraArgs='{--default-issuer-name=letsencrypt-prod,--default-issuer-kind=ClusterIssuer}' stable/cert-manager")
+	FatalOnError(err)
+	log.Println("cert-manager installed")
+}
+
+func (addon CertmanagerAddon) Uninstall() {
+	node := *addon.masterNode
+	_, err := runCmd(node, "helm delete --purge cert-manager")
+	FatalOnError(err)
+	log.Println("cert-manager uninstalled")
+}

--- a/cmd/addon_ingress.go
+++ b/cmd/addon_ingress.go
@@ -23,5 +23,5 @@ func (addon IngressAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := runCmd(node, "helm delete --purge ingress")
 	FatalOnError(err)
-	log.Println("nginx ingress installed")
+	log.Println("nginx ingress uninstalled")
 }

--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -7,7 +7,7 @@ type ClusterAddon interface {
 
 func AddonExists(addonName string) bool {
 	switch addonName {
-	case "helm", "rook", "ingress", "openebs":
+	case "helm", "rook", "ingress", "openebs", "cert-manager":
 		return true
 	default:
 		return false
@@ -24,6 +24,8 @@ func (cluster Cluster) GetAddon(addonName string) ClusterAddon {
 		return NewIngressAddon(cluster)
 	case "openebs":
 		return NewOpenEBSAddon(cluster)
+	case "cert-manager":
+		return NewCertmanagerAddon(cluster)
 	default:
 		return nil
 	}


### PR DESCRIPTION
* adds cert-manager as addon which should be able to provide letsencrypt certificates for ingress
* fixes a typo in addon_ingress