### PR TITLE
Remove unecessary arg from cert-manager

### DIFF
--- a/cmd/addon_cert-manager.go
+++ b/cmd/addon_cert-manager.go
@@ -14,7 +14,7 @@ func NewCertmanagerAddon(cluster Cluster) ClusterAddon {
 
 func (addon CertmanagerAddon) Install(args ... string) {
 	node := *addon.masterNode
-	_, err := runCmd(node, "helm install --name cert-manager --namespace kube-system stable/cert-manager")
+	_, err := runCmd(node, "helm install --name cert-manager --namespace ingress stable/cert-manager")
 	FatalOnError(err)
 	log.Println("cert-manager installed")
 }

--- a/cmd/addon_cert-manager.go
+++ b/cmd/addon_cert-manager.go
@@ -14,7 +14,7 @@ func NewCertmanagerAddon(cluster Cluster) ClusterAddon {
 
 func (addon CertmanagerAddon) Install(args ... string) {
 	node := *addon.masterNode
-	_, err := runCmd(node, "helm install --name cert-manager --namespace kube-system --set ingressShim.extraArgs='{--default-issuer-name=letsencrypt-prod,--default-issuer-kind=ClusterIssuer}' stable/cert-manager")
+	_, err := runCmd(node, "helm install --name cert-manager --namespace kube-system stable/cert-manager")
 	FatalOnError(err)
 	log.Println("cert-manager installed")
 }


### PR DESCRIPTION
This arg is to maintain backward compatibility with kube-lego.