### PR TITLE
feat: add the possibility to set the install file url

### DIFF
--- a/cmd/cluster_add_worker.go
+++ b/cmd/cluster_add_worker.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/xetys/hetzner-kube/pkg"
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
 	"log"
 	"strconv"
 	"strings"
 	"time"
-	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
 // clusterAddWorkerCmd represents the clusterAddWorker command

--- a/cmd/cluster_addon_install.go
+++ b/cmd/cluster_addon_install.go
@@ -17,9 +17,9 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/xetys/hetzner-kube/pkg/addons"
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
 	"log"
-	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
 // clusterAddonInstallCmd represents the clusterAddonInstall command

--- a/cmd/cluster_addon_uninstall.go
+++ b/cmd/cluster_addon_uninstall.go
@@ -17,9 +17,9 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/xetys/hetzner-kube/pkg/addons"
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
 	"log"
-	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
 // clusterAddonInstallCmd represents the clusterAddonInstall command

--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -56,6 +56,7 @@ func RunClusterCreate(cmd *cobra.Command, args []string) {
 	masterCount, _ := cmd.Flags().GetInt("master-count")
 	etcdCount, _ := cmd.Flags().GetInt("etcd-count")
 	haEnabled, _ := cmd.Flags().GetBool("ha-enabled")
+	installFileURL, _ := cmd.Flags().GetString("install-file-url")
 	if !haEnabled {
 		masterCount = 1
 	}
@@ -104,10 +105,10 @@ func RunClusterCreate(cmd *cobra.Command, args []string) {
 		time.Sleep(30 * time.Second)
 	}
 
-
 	coordinator := pkg.NewProgressCoordinator()
 
-	clusterManager := clustermanager.NewClusterManager(hetznerProvider, sshClient, coordinator, clusterName, haEnabled, isolatedEtcd, cloudInit, false)
+	clusterManager := clustermanager.NewClusterManager(hetznerProvider, sshClient, coordinator, clusterName, haEnabled,
+		isolatedEtcd, cloudInit, false, installFileURL)
 	cluster := clusterManager.Cluster()
 	RenderProgressBars(&cluster, coordinator)
 
@@ -291,5 +292,6 @@ func init() {
 	clusterCreateCmd.Flags().Bool("self-hosted", false, "If true, the kubernetes control plane will be hosted on itself")
 	clusterCreateCmd.Flags().IntP("worker-count", "w", 1, "Number of worker nodes for the cluster")
 	clusterCreateCmd.Flags().StringP("cloud-init", "", "", "Cloud-init file for server preconfiguration")
+	clusterCreateCmd.Flags().StringP("install-file-url", "", "https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh", "URL of the install file that should be used")
 	clusterCreateCmd.Flags().StringSlice("datacenters", []string{"nbg1-dc3", "fsn1-dc8"}, "Can be used to filter datacenters by their name")
 }

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
 	"strings"
-	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
 // clusterKubeconfigCmd represents the clusterKubeconfig command

--- a/pkg/clustermanager/ssh_communicator.go
+++ b/pkg/clustermanager/ssh_communicator.go
@@ -29,7 +29,7 @@ var _ NodeCommunicator = &SSHCommunicator{}
 
 func NewSSHCommunicator(sshKeys []SSHKey) NodeCommunicator {
 	return &SSHCommunicator{
-		sshKeys: sshKeys,
+		sshKeys:     sshKeys,
 		passPhrases: make(map[string][]byte),
 	}
 }


### PR DESCRIPTION
This can be useful if the user want to hook into the installtion. I used it to make kube-prometheus work, as I needed to append some arguments to the kubelet.