### PR TITLE
Cluster Addon Redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ $ go get -u github.com/xetys/hetzner-kube
 
 In your [Hetzner Console](https://console.hetzner.cloud) generate an API token and
 
-```
+```bash
 $ hetzner-kube context add my-project
 Token: <PASTE-TOKEN-HERE>
 ```
 
 Then you need to add an SSH key:
 
-```
+```bash
 $ hetzner-kube ssh-key add -n my-key
 ```
 
@@ -42,7 +42,7 @@ This assumes, you already have a SSH keypair `~/.ssh/id_rsa` and `~/.ssh/id_rsa.
 
 And finally you can create a cluster by running:
 
-```
+```bash
 $ hetzner-kube cluster create --name my-cluster --ssh-key my-key
 
 ```
@@ -59,19 +59,15 @@ further information.
 
 ## addons
 
-You can install some addons to your cluster using the `cluster addon` sub-command. Currently these are the supported first addons:
+You can install some addons to your cluster using the `cluster addon` sub-command. Get a list of addons using:
 
-* helm
-* [Rook](https://rook.io)
-* OpenEBS
-* NGinx ingress controller (requires helm)
-* [cert-manager](https://github.com/jetstack/cert-manager) (requires helm)
-* [docker-registry](https://github.com/kubernetes/charts/tree/master/stable/docker-registry) (requires PVC)
+```bash
+$ hetzner-kube cluster addon list
+```
 
 ### contributing new addons
 
-Feel free to contribute cluster addons. You can simply create one by implementing the `ClusterAddon` interface and 
-adding it to the addons.
+You want to add some cool stuff to hetzner-kube? It's quite easy! Learn how to add new addons in the [Developing Addons](docs/cluster-addons.md) documentation.
 
 ## cloud-init
 

--- a/cmd/cluster_addon_list.go
+++ b/cmd/cluster_addon_list.go
@@ -15,14 +15,14 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"text/tabwriter"
-	"os"
 	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/xetys/hetzner-kube/pkg/addons"
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
-	"github.com/xetys/hetzner-kube/pkg/addons"
+	"os"
 	"strings"
+	"text/tabwriter"
 )
 
 // clusterAddonInstallCmd represents the clusterAddonInstall command

--- a/docs/cluster-addons.md
+++ b/docs/cluster-addons.md
@@ -39,6 +39,10 @@ func (addon *NginxAddon) Name() string {
 	return "nginx"
 }
 
+func (addon *NginxAddon) Requires() []string {
+	return []string{}
+}
+
 func (addon *NginxAddon) Description() string {
 	return "a simple nginx deployment"
 }

--- a/docs/cluster-addons.md
+++ b/docs/cluster-addons.md
@@ -1,0 +1,89 @@
+# Developing addons for hetzner-kube
+
+As of 0.3 adding cluster addons is quite easy, and can happen without altering the core code.
+You only need to implement the `ClusterAddon` interface and provide a `ClusterAddonInitializer` to
+register your addon to hetzner-kube.
+
+
+## Step 1: Implement the `ClusterAddon` interface
+
+A cluster interface is described by the following interface:
+
+```go
+type ClusterAddon interface {
+	Name() string
+	Description() string
+	URL() string
+	Install(args ...string)
+	Uninstall()
+}
+```
+
+To implement an addon which installs a simple nginx deployment, the addon should be configured like this:
+
+
+```go
+
+type NginxAddon struct {
+	masterNode   *clustermanager.Node
+	communicator clustermanager.NodeCommunicator
+}
+
+func NewNginxAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
+	masterNode, err := provider.GetMasterNode()
+	FatalOnError(err)
+	return &NginxAddon{masterNode: masterNode, communicator: communicator}
+}
+
+func (addon *NginxAddon) Name() string {
+	return "nginx"
+}
+
+func (addon *NginxAddon) Description() string {
+	return "a simple nginx deployment"
+}
+
+func (addon *NginxAddon) URL() string {
+	return ""
+}
+
+func (addon *NginxAddon) Install(args ...string) {
+	node := *addon.masterNode
+	_, err := addon.communicator.RunCmd(node, "kubectl run nginx --image nginx")
+	FatalOnError(err)
+	log.Println("nginx installed")
+}
+
+func (addon *NginxAddon) Uninstall() {
+	node := *addon.masterNode
+	_, err := addon.communicator.RunCmd(node, "kubectl delete deployment nginx")
+	FatalOnError(err)
+	log.Println("nginx uninstalled")
+}
+
+```
+
+The type should have a field with the pointer to the master node (for running `kubectl` or `helm`) and a node communicator 
+(most commonly a SSH client) to run commands. In `NewNginxAddon` an `ClusterProvider` and `NodeCommunicator` instances are injected
+so you can use them for getting the master node. You can use different data given by provider and define a different
+type for your addon with custom fields, as long the type still implements `ClusterAddon`.
+
+## Step 2: Register your addon
+
+In the same file you add these lines:
+
+```go
+
+func init() {
+	addAddon(NewNginxAddon)
+}
+
+```
+
+`addAddon` expects a `ClusterAddonInitializer`, which is a function with a provider and node communicator as parameter 
+and returning a `ClusterAddon` instance, which is satisfied by `NewNginxAddon`.
+
+
+## Test
+
+If all done right, you should see now your addon by doing `./hetzner-kube cluster addon list`

--- a/pkg/addons/addon_cert_manager.go
+++ b/pkg/addons/addon_cert_manager.go
@@ -5,6 +5,7 @@ import (
 	"log"
 )
 
+//CertmanagerAddon installs cert-manager
 type CertmanagerAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
@@ -49,6 +50,7 @@ func (addon *CertmanagerAddon) Install(args ...string) {
 	log.Println("cert-manager installed")
 }
 
+//Uninstall performs all steps to remove the addon
 func (addon *CertmanagerAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm delete --purge cert-manager")

--- a/pkg/addons/addon_cert_manager.go
+++ b/pkg/addons/addon_cert_manager.go
@@ -10,6 +10,7 @@ type CertmanagerAddon struct {
 	communicator clustermanager.NodeCommunicator
 }
 
+// NewCertmanagerAddon creates an addon installing cert-manager
 func NewCertmanagerAddon(cluster clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, err := cluster.GetMasterNode()
 	FatalOnError(err)
@@ -20,21 +21,27 @@ func init() {
 	addAddon(NewCertmanagerAddon)
 }
 
+//Name returns the addons name
 func (addon *CertmanagerAddon) Name() string {
 	return "cert-manager"
 }
 
+//Requires returns a slice with the name of required addons
 func (addon *CertmanagerAddon) Requires() []string {
 	return []string{"helm"}
 }
 
+//Description returns the addons description
 func (addon *CertmanagerAddon) Description() string {
 	return "Auto-TLS provisioning & management"
 }
 
+//URL returns the URL of the addons underlying project
 func (addon *CertmanagerAddon) URL() string {
 	return "https://github.com/jetstack/cert-manager"
 }
+
+//Install performs all steps to install the addon
 func (addon *CertmanagerAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --name cert-manager --namespace ingress stable/cert-manager")

--- a/pkg/addons/addon_cert_manager.go
+++ b/pkg/addons/addon_cert_manager.go
@@ -16,6 +16,21 @@ func NewCertmanagerAddon(cluster clustermanager.ClusterProvider, communicator cl
 	return &CertmanagerAddon{masterNode: masterNode, communicator: communicator}
 }
 
+func init() {
+	addAddon(NewCertmanagerAddon)
+}
+
+func (addon *CertmanagerAddon) Name() string {
+	return "cert-manager"
+}
+
+func (addon *CertmanagerAddon) Description() string {
+	return "Auto-TLS provisioning & management"
+}
+
+func (addon *CertmanagerAddon) URL() string {
+	return "https://github.com/jetstack/cert-manager"
+}
 func (addon *CertmanagerAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --name cert-manager --namespace ingress stable/cert-manager")

--- a/pkg/addons/addon_cert_manager.go
+++ b/pkg/addons/addon_cert_manager.go
@@ -24,6 +24,10 @@ func (addon *CertmanagerAddon) Name() string {
 	return "cert-manager"
 }
 
+func (addon *CertmanagerAddon) Requires() []string {
+	return []string{"helm"}
+}
+
 func (addon *CertmanagerAddon) Description() string {
 	return "Auto-TLS provisioning & management"
 }

--- a/pkg/addons/addon_docker_registry.go
+++ b/pkg/addons/addon_docker_registry.go
@@ -16,6 +16,22 @@ func NewDockerregistryAddon(provider clustermanager.ClusterProvider, communicato
 	return &DockerregistryAddon{masterNode: masterNode, communicator: communicator}
 }
 
+func init() {
+	addAddon(NewDockerregistryAddon)
+}
+
+func (addon *DockerregistryAddon) Name() string {
+	return "docker-registry"
+}
+
+func (addon *DockerregistryAddon) Description() string {
+	return "Private container registry"
+}
+
+func (addon *DockerregistryAddon) URL() string {
+	return ""
+}
+
 func (addon *DockerregistryAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --set persistence.enabled=true stable/docker-registry")

--- a/pkg/addons/addon_docker_registry.go
+++ b/pkg/addons/addon_docker_registry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 )
 
+//DockerregistryAddon installs a private container registry
 type DockerregistryAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator

--- a/pkg/addons/addon_docker_registry.go
+++ b/pkg/addons/addon_docker_registry.go
@@ -24,12 +24,16 @@ func (addon *DockerregistryAddon) Name() string {
 	return "docker-registry"
 }
 
+func (addon *DockerregistryAddon) Requires() []string {
+	return []string{"helm"}
+}
+
 func (addon *DockerregistryAddon) Description() string {
 	return "Private container registry"
 }
 
 func (addon *DockerregistryAddon) URL() string {
-	return ""
+	return "https://github.com/kubernetes/charts/tree/master/stable/docker-registry"
 }
 
 func (addon *DockerregistryAddon) Install(args ...string) {

--- a/pkg/addons/addon_docker_registry.go
+++ b/pkg/addons/addon_docker_registry.go
@@ -10,6 +10,7 @@ type DockerregistryAddon struct {
 	communicator clustermanager.NodeCommunicator
 }
 
+// NewDockerregistryAddon creates an addon providing a private docker registry
 func NewDockerregistryAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, err := provider.GetMasterNode()
 	FatalOnError(err)
@@ -20,22 +21,27 @@ func init() {
 	addAddon(NewDockerregistryAddon)
 }
 
+//Name returns the addons name
 func (addon *DockerregistryAddon) Name() string {
 	return "docker-registry"
 }
 
+//Requires returns a slice with the name of required addons
 func (addon *DockerregistryAddon) Requires() []string {
 	return []string{"helm"}
 }
 
+//Description returns the addons description
 func (addon *DockerregistryAddon) Description() string {
 	return "Private container registry"
 }
 
+//URL returns the URL of the addons underlying project
 func (addon *DockerregistryAddon) URL() string {
 	return "https://github.com/kubernetes/charts/tree/master/stable/docker-registry"
 }
 
+//Install performs all steps to install the addon
 func (addon *DockerregistryAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --set persistence.enabled=true stable/docker-registry")
@@ -43,6 +49,7 @@ func (addon *DockerregistryAddon) Install(args ...string) {
 	log.Println("docker-registry installed")
 }
 
+//Uninstall performs all steps to remove the addon
 func (addon DockerregistryAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm delete --purge docker-registry")

--- a/pkg/addons/addon_helm.go
+++ b/pkg/addons/addon_helm.go
@@ -23,6 +23,10 @@ func (addon HelmAddon) Name() string {
 	return "helm"
 }
 
+func (addon HelmAddon) Requires() []string {
+	return []string{}
+}
+
 func (addon HelmAddon) Description() string {
 	return "Kuberntes Package Manager"
 }

--- a/pkg/addons/addon_helm.go
+++ b/pkg/addons/addon_helm.go
@@ -5,6 +5,7 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
+//HelmAddon installs helm
 type HelmAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator

--- a/pkg/addons/addon_helm.go
+++ b/pkg/addons/addon_helm.go
@@ -10,6 +10,7 @@ type HelmAddon struct {
 	communicator clustermanager.NodeCommunicator
 }
 
+//NewHelmAddon installs helm to the cluster
 func NewHelmAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, _ := provider.GetMasterNode()
 	return HelmAddon{masterNode: masterNode, communicator: communicator}
@@ -19,22 +20,27 @@ func init() {
 	addAddon(NewHelmAddon)
 }
 
+//Name returns the addons name
 func (addon HelmAddon) Name() string {
 	return "helm"
 }
 
+//Requires returns a slice with the name of required addons
 func (addon HelmAddon) Requires() []string {
 	return []string{}
 }
 
+//Description returns the addons description
 func (addon HelmAddon) Description() string {
 	return "Kuberntes Package Manager"
 }
 
+//URL returns the URL of the addons underlying project
 func (addon HelmAddon) URL() string {
 	return "https://helm.sh"
 }
 
+//Install performs all steps to install the addon
 func (addon HelmAddon) Install(args ...string) {
 
 	node := *addon.masterNode
@@ -70,6 +76,7 @@ subjects:
 	fmt.Println("Helm installed")
 }
 
+//Uninstall performs all steps to remove the addon
 func (addon HelmAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm reset --force")

--- a/pkg/addons/addon_helm.go
+++ b/pkg/addons/addon_helm.go
@@ -15,6 +15,22 @@ func NewHelmAddon(provider clustermanager.ClusterProvider, communicator clusterm
 	return HelmAddon{masterNode: masterNode, communicator: communicator}
 }
 
+func init() {
+	addAddon(NewHelmAddon)
+}
+
+func (addon HelmAddon) Name() string {
+	return "helm"
+}
+
+func (addon HelmAddon) Description() string {
+	return "Kuberntes Package Manager"
+}
+
+func (addon HelmAddon) URL() string {
+	return "https://helm.sh"
+}
+
 func (addon HelmAddon) Install(args ...string) {
 
 	node := *addon.masterNode

--- a/pkg/addons/addon_ingress.go
+++ b/pkg/addons/addon_ingress.go
@@ -5,6 +5,7 @@ import (
 	"log"
 )
 
+//IngressAddon installs an ingress controller
 type IngressAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator

--- a/pkg/addons/addon_ingress.go
+++ b/pkg/addons/addon_ingress.go
@@ -24,6 +24,10 @@ func (addon *IngressAddon) Name() string {
 	return "nginx ingress controller"
 }
 
+func (addon *IngressAddon) Requires() []string {
+	return []string{"helm"}
+}
+
 func (addon *IngressAddon) Description() string {
 	return "an ingress based load balancer for K8S"
 }

--- a/pkg/addons/addon_ingress.go
+++ b/pkg/addons/addon_ingress.go
@@ -10,6 +10,7 @@ type IngressAddon struct {
 	communicator clustermanager.NodeCommunicator
 }
 
+//NewIngressAddon creates an addon to install a nginx ingress controller
 func NewIngressAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, err := provider.GetMasterNode()
 	FatalOnError(err)
@@ -20,22 +21,27 @@ func init() {
 	addAddon(NewIngressAddon)
 }
 
+//Name returns the addons name
 func (addon *IngressAddon) Name() string {
 	return "nginx ingress controller"
 }
 
+//Requires returns a slice with the name of required addons
 func (addon *IngressAddon) Requires() []string {
 	return []string{"helm"}
 }
 
+//Description returns the addons description
 func (addon *IngressAddon) Description() string {
 	return "an ingress based load balancer for K8S"
 }
 
+//URL returns the URL of the addons underlying project
 func (addon *IngressAddon) URL() string {
 	return ""
 }
 
+//Install performs all steps to install the addon
 func (addon *IngressAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --name ingress --namespace ingress --set rbac.create=true,controller.kind=DaemonSet,controller.service.type=ClusterIP,controller.hostNetwork=true stable/nginx-ingress")
@@ -43,6 +49,7 @@ func (addon *IngressAddon) Install(args ...string) {
 	log.Println("nginx ingress installed")
 }
 
+//Uninstall performs all steps to remove the addon
 func (addon *IngressAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm delete --purge ingress")

--- a/pkg/addons/addon_ingress.go
+++ b/pkg/addons/addon_ingress.go
@@ -16,6 +16,22 @@ func NewIngressAddon(provider clustermanager.ClusterProvider, communicator clust
 	return &IngressAddon{masterNode: masterNode, communicator: communicator}
 }
 
+func init() {
+	addAddon(NewIngressAddon)
+}
+
+func (addon *IngressAddon) Name() string {
+	return "nginx ingress controller"
+}
+
+func (addon *IngressAddon) Description() string {
+	return "an ingress based load balancer for K8S"
+}
+
+func (addon *IngressAddon) URL() string {
+	return ""
+}
+
 func (addon *IngressAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --name ingress --namespace ingress --set rbac.create=true,controller.kind=DaemonSet,controller.service.type=ClusterIP,controller.hostNetwork=true stable/nginx-ingress")

--- a/pkg/addons/addon_openebs.go
+++ b/pkg/addons/addon_openebs.go
@@ -10,6 +10,7 @@ type OpenEBSAddon struct {
 	communicator clustermanager.NodeCommunicator
 }
 
+//NewOpenEBSAddon creates an addon which installs OpenEBS
 func NewOpenEBSAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, _ := provider.GetMasterNode()
 	return &OpenEBSAddon{masterNode: masterNode, communicator: communicator}
@@ -19,22 +20,27 @@ func init() {
 	addAddon(NewOpenEBSAddon)
 }
 
+//Name returns the addons name
 func (addon OpenEBSAddon) Name() string {
 	return "OpenEBS"
 }
 
+//Requires returns a slice with the name of required addons
 func (addon OpenEBSAddon) Requires() []string {
 	return []string{}
 }
 
+//Description returns the addons description
 func (addon OpenEBSAddon) Description() string {
 	return "Simple scalable block storage provider"
 }
 
+//URL returns the URL of the addons underlying project
 func (addon OpenEBSAddon) URL() string {
 	return "https://openebs.io/"
 }
 
+//Install performs all steps to install the addon
 func (addon OpenEBSAddon) Install(args ...string) {
 	node := *addon.masterNode
 
@@ -60,6 +66,7 @@ parameters:
 	fmt.Println("OpenEBS installed")
 }
 
+//Uninstall performs all steps to remove the addon
 func (addon OpenEBSAddon) Uninstall() {
 	node := *addon.masterNode
 

--- a/pkg/addons/addon_openebs.go
+++ b/pkg/addons/addon_openebs.go
@@ -5,6 +5,7 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
+//OpenEBSAddon installs OpenEBS
 type OpenEBSAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator

--- a/pkg/addons/addon_openebs.go
+++ b/pkg/addons/addon_openebs.go
@@ -23,6 +23,10 @@ func (addon OpenEBSAddon) Name() string {
 	return "OpenEBS"
 }
 
+func (addon OpenEBSAddon) Requires() []string {
+	return []string{}
+}
+
 func (addon OpenEBSAddon) Description() string {
 	return "Simple scalable block storage provider"
 }

--- a/pkg/addons/addon_openebs.go
+++ b/pkg/addons/addon_openebs.go
@@ -15,6 +15,22 @@ func NewOpenEBSAddon(provider clustermanager.ClusterProvider, communicator clust
 	return &OpenEBSAddon{masterNode: masterNode, communicator: communicator}
 }
 
+func init() {
+	addAddon(NewOpenEBSAddon)
+}
+
+func (addon OpenEBSAddon) Name() string {
+	return "OpenEBS"
+}
+
+func (addon OpenEBSAddon) Description() string {
+	return "Simple scalable block storage provider"
+}
+
+func (addon OpenEBSAddon) URL() string {
+	return "https://openebs.io/"
+}
+
 func (addon OpenEBSAddon) Install(args ...string) {
 	node := *addon.masterNode
 

--- a/pkg/addons/addon_rook.go
+++ b/pkg/addons/addon_rook.go
@@ -17,6 +17,22 @@ func NewRookAddon(provider clustermanager.ClusterProvider, communicator clusterm
 	return &RookAddon{masterNode: masterNode, communicator: communicator, nodes: provider.GetAllNodes()}
 }
 
+func init() {
+	addAddon(NewRookAddon)
+}
+
+func (addon RookAddon) Name() string {
+	return "rook"
+}
+
+func (addon RookAddon) Description() string {
+	return "File, Block and Object Storage provider"
+}
+
+func (addon RookAddon) URL() string {
+	return "https://rook.io"
+}
+
 func (addon RookAddon) Install(args ...string) {
 	node := *addon.masterNode
 

--- a/pkg/addons/addon_rook.go
+++ b/pkg/addons/addon_rook.go
@@ -12,6 +12,7 @@ type RookAddon struct {
 	nodes        []clustermanager.Node
 }
 
+//NewRookAddon creates an addon which install rook
 func NewRookAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, _ := provider.GetMasterNode()
 	return &RookAddon{masterNode: masterNode, communicator: communicator, nodes: provider.GetAllNodes()}
@@ -21,22 +22,27 @@ func init() {
 	addAddon(NewRookAddon)
 }
 
+//Name returns the addons name
 func (addon RookAddon) Name() string {
 	return "rook"
 }
 
+//Requires returns a slice with the name of required addons
 func (addon RookAddon) Requires() []string {
 	return []string{}
 }
 
+//Description returns the addons description
 func (addon RookAddon) Description() string {
 	return "File, Block and Object Storage provider"
 }
 
+//URL returns the URL of the addons underlying project
 func (addon RookAddon) URL() string {
 	return "https://rook.io"
 }
 
+//Install performs all steps to install the addon
 func (addon RookAddon) Install(args ...string) {
 	node := *addon.masterNode
 
@@ -64,6 +70,7 @@ func (addon RookAddon) Install(args ...string) {
 	fmt.Println("Rook installed")
 }
 
+//Uninstall performs all steps to remove the addon
 func (addon RookAddon) Uninstall() {
 	node := *addon.masterNode
 	addon.communicator.RunCmd(node, "kubectl delete -n rook pool replicapool")

--- a/pkg/addons/addon_rook.go
+++ b/pkg/addons/addon_rook.go
@@ -25,6 +25,10 @@ func (addon RookAddon) Name() string {
 	return "rook"
 }
 
+func (addon RookAddon) Requires() []string {
+	return []string{}
+}
+
 func (addon RookAddon) Description() string {
 	return "File, Block and Object Storage provider"
 }

--- a/pkg/addons/addon_rook.go
+++ b/pkg/addons/addon_rook.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+//RookAddon installs rook
 type RookAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator

--- a/pkg/addons/cluster_addon.go
+++ b/pkg/addons/cluster_addon.go
@@ -3,43 +3,54 @@ package addons
 import "github.com/xetys/hetzner-kube/pkg/clustermanager"
 
 type ClusterAddon interface {
+	Name() string
+	Description() string
+	URL() string
 	Install(args ...string)
 	Uninstall()
+}
+
+type ClusterAddonInitializer func(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon
+
+var addonInitializers []ClusterAddonInitializer = make([]ClusterAddonInitializer, 0)
+
+func addAddon(clusterAddon ClusterAddonInitializer) {
+	addonInitializers = append(addonInitializers, clusterAddon)
 }
 
 type ClusterAddonService struct {
 	provider         clustermanager.ClusterProvider
 	nodeCommunicator clustermanager.NodeCommunicator
+	addons           []ClusterAddon
 }
 
 func NewClusterAddonService(provider clustermanager.ClusterProvider, nodeComm clustermanager.NodeCommunicator) *ClusterAddonService {
-	return &ClusterAddonService{provider: provider, nodeCommunicator: nodeComm}
+	clusterAddons := []ClusterAddon{}
+	for _, initializer := range addonInitializers {
+		clusterAddons = append(clusterAddons, initializer(provider, nodeComm))
+	}
+	return &ClusterAddonService{provider: provider, nodeCommunicator: nodeComm, addons: clusterAddons}
 }
 
-func (ClusterAddonService) AddonExists(addonName string) bool {
-	switch addonName {
-	case "helm", "rook", "ingress", "openebs", "cert-manager", "docker-registry":
-		return true
-	default:
-		return false
+func (addonService *ClusterAddonService) AddonExists(addonName string) bool {
+	for _, addon := range addonService.addons {
+		if addon.Name() == addonName {
+			return true
+		}
 	}
+	return false
 }
 
-func (addonService ClusterAddonService) GetAddon(addonName string) ClusterAddon {
-	switch addonName {
-	case "helm":
-		return NewHelmAddon(addonService.provider, addonService.nodeCommunicator)
-	case "rook":
-		return NewRookAddon(addonService.provider, addonService.nodeCommunicator)
-	case "ingress":
-		return NewIngressAddon(addonService.provider, addonService.nodeCommunicator)
-	case "openebs":
-		return NewOpenEBSAddon(addonService.provider, addonService.nodeCommunicator)
-	case "cert-manager":
-		return NewCertmanagerAddon(addonService.provider, addonService.nodeCommunicator)
-	case "docker-registry":
-		return NewDockerregistryAddon(addonService.provider, addonService.nodeCommunicator)
-	default:
-		return nil
+func (addonService *ClusterAddonService) GetAddon(addonName string) ClusterAddon {
+	for _, addon := range addonService.addons {
+		if addon.Name() == addonName {
+			return addon
+		}
 	}
+
+	return nil
+}
+
+func (addonService *ClusterAddonService) Addons() []ClusterAddon {
+	return addonService.addons
 }

--- a/pkg/addons/cluster_addon.go
+++ b/pkg/addons/cluster_addon.go
@@ -4,6 +4,7 @@ import "github.com/xetys/hetzner-kube/pkg/clustermanager"
 
 type ClusterAddon interface {
 	Name() string
+	Requires() []string
 	Description() string
 	URL() string
 	Install(args ...string)

--- a/pkg/addons/cluster_addon.go
+++ b/pkg/addons/cluster_addon.go
@@ -13,7 +13,7 @@ type ClusterAddon interface {
 
 type ClusterAddonInitializer func(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon
 
-var addonInitializers []ClusterAddonInitializer = make([]ClusterAddonInitializer, 0)
+var addonInitializers = make([]ClusterAddonInitializer, 0)
 
 func addAddon(clusterAddon ClusterAddonInitializer) {
 	addonInitializers = append(addonInitializers, clusterAddon)

--- a/pkg/addons/cluster_addon.go
+++ b/pkg/addons/cluster_addon.go
@@ -25,6 +25,7 @@ type ClusterAddonService struct {
 	addons           []ClusterAddon
 }
 
+//NewClusterAddonService creates an instance of the cluster addon service
 func NewClusterAddonService(provider clustermanager.ClusterProvider, nodeComm clustermanager.NodeCommunicator) *ClusterAddonService {
 	clusterAddons := []ClusterAddon{}
 	for _, initializer := range addonInitializers {
@@ -33,6 +34,7 @@ func NewClusterAddonService(provider clustermanager.ClusterProvider, nodeComm cl
 	return &ClusterAddonService{provider: provider, nodeCommunicator: nodeComm, addons: clusterAddons}
 }
 
+//AddonExists return true, if an addon with the requested name exists
 func (addonService *ClusterAddonService) AddonExists(addonName string) bool {
 	for _, addon := range addonService.addons {
 		if addon.Name() == addonName {
@@ -42,6 +44,7 @@ func (addonService *ClusterAddonService) AddonExists(addonName string) bool {
 	return false
 }
 
+//GetAddon returns the ClusterAddon instance given by name, or nil if not found
 func (addonService *ClusterAddonService) GetAddon(addonName string) ClusterAddon {
 	for _, addon := range addonService.addons {
 		if addon.Name() == addonName {
@@ -52,6 +55,7 @@ func (addonService *ClusterAddonService) GetAddon(addonName string) ClusterAddon
 	return nil
 }
 
+//Addons returns a list of all addons
 func (addonService *ClusterAddonService) Addons() []ClusterAddon {
 	return addonService.addons
 }

--- a/pkg/addons/cluster_addon.go
+++ b/pkg/addons/cluster_addon.go
@@ -2,6 +2,7 @@ package addons
 
 import "github.com/xetys/hetzner-kube/pkg/clustermanager"
 
+//ClusterAddon describes what functions a cluster addon should provide, so the addon system can use it for the cmd
 type ClusterAddon interface {
 	Name() string
 	Requires() []string
@@ -11,6 +12,7 @@ type ClusterAddon interface {
 	Uninstall()
 }
 
+//ClusterAddonInitializer is a function creating ClusterAddon instances from given parameters
 type ClusterAddonInitializer func(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon
 
 var addonInitializers = make([]ClusterAddonInitializer, 0)

--- a/pkg/clustermanager/ssh_communicator.go
+++ b/pkg/clustermanager/ssh_communicator.go
@@ -29,7 +29,7 @@ var _ NodeCommunicator = &SSHCommunicator{}
 
 func NewSSHCommunicator(sshKeys []SSHKey) NodeCommunicator {
 	return &SSHCommunicator{
-		sshKeys: sshKeys,
+		sshKeys:     sshKeys,
 		passPhrases: make(map[string][]byte),
 	}
 }


### PR DESCRIPTION
This PR introduces a little redesign of the addon system. Developers now are able to provide new addons just by adding a file in `pkg/addons` containing a type, which implements `ClusterAddon`, a `ClusterAddonInitializer` which is added using `addAddon(ClusterAddonInitializer)` in the `init` function. Check the upgraded existing addons or the documentation for sample code.

fixes #59 