### PR TITLE
move hcloud-controller-manager to addon, improve installation

### DIFF
--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -169,7 +169,7 @@ func saveCluster(cluster *clustermanager.Cluster) {
 
 func RenderProgressBars(cluster *clustermanager.Cluster, coordinator *pkg.UiProgressCoordinator) {
 	nodes := cluster.Nodes
-	provisionSteps := 2
+	provisionSteps := 5
 	netWorkSetupSteps := 2
 	etcdSteps := 4
 	masterInstallSteps := 2
@@ -214,7 +214,7 @@ func RenderProgressBars(cluster *clustermanager.Cluster, coordinator *pkg.UiProg
 			}
 		}
 
-		coordinator.StartProgress(node.Name, steps+9)
+		coordinator.StartProgress(node.Name, steps+6)
 	}
 }
 

--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -214,7 +214,7 @@ func RenderProgressBars(cluster *clustermanager.Cluster, coordinator *pkg.UiProg
 			}
 		}
 
-		coordinator.StartProgress(node.Name, steps+6)
+		coordinator.StartProgress(node.Name, steps+9)
 	}
 }
 

--- a/pkg/addons/addon_hcloud_controller_manager.go
+++ b/pkg/addons/addon_hcloud_controller_manager.go
@@ -1,0 +1,90 @@
+package addons
+
+import (
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
+	"fmt"
+	"github.com/xetys/hetzner-kube/pkg/hetzner"
+)
+
+// HCloudControllerManagerAddon installs hetzner clouds official cloud controller manager
+type HCloudControllerManagerAddon struct {
+	masterNode   *clustermanager.Node
+	communicator clustermanager.NodeCommunicator
+	nodes        []clustermanager.Node
+	provider     *hetzner.Provider
+}
+
+// NewHCloudControllerManagerAddon returns a CloudProvider instance with type HCloudControllerManagerAddon
+func NewHCloudControllerManagerAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
+	masterNode, err := provider.GetMasterNode()
+	FatalOnError(err)
+	return &HCloudControllerManagerAddon{
+		masterNode:   masterNode,
+		communicator: communicator,
+		nodes:        provider.GetAllNodes(),
+		provider:     provider.(*hetzner.Provider),
+	}
+}
+
+func init() {
+	addAddon(NewHCloudControllerManagerAddon)
+}
+
+//Name returns the addons name
+func (addon *HCloudControllerManagerAddon) Name() string {
+	return "hcloud-controller-manager"
+}
+
+//Requires returns a slice with the name of required addons
+func (addon *HCloudControllerManagerAddon) Requires() []string {
+	return []string{}
+}
+
+//Description returns the addons description
+func (addon *HCloudControllerManagerAddon) Description() string {
+	return "Hetzner Cloud official cloud controller manager"
+}
+
+//URL returns the URL of the addons underlying project
+func (addon *HCloudControllerManagerAddon) URL() string {
+	return "https://github.com/hetznercloud/hcloud-cloud-controller-manager"
+}
+
+//Install performs all steps to install the addon
+func (addon *HCloudControllerManagerAddon) Install(args ...string) {
+	// set external cloud provider
+	config := `
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
+`
+	for _, node := range addon.nodes {
+		err := addon.communicator.WriteFile(node, "/etc/systemd/system/kubelet.service.d/20-hcloud.conf", config, false)
+		FatalOnError(err)
+
+		_, err = addon.communicator.RunCmd(node, "systemctl daemon-reload && systemctl restart kubelet")
+		FatalOnError(err)
+	}
+
+	_, err := addon.communicator.RunCmd(*addon.masterNode, `kubectl -n kube-system patch ds kube-flannel-ds --type json -p '[{"op":"add","path":"/spec/template/spec/tolerations/-","value":{"key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true","effect":"NoSchedule"}}]'`)
+	FatalOnError(err)
+	_, err = addon.communicator.RunCmd(*addon.masterNode, fmt.Sprintf("kubectl -n kube-system create secret generic hcloud --from-literal=token=%s", addon.provider.Token()))
+	FatalOnError(err)
+	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.2.0.yaml")
+	FatalOnError(err)
+}
+
+//Uninstall performs all steps to remove the addon
+func (addon *HCloudControllerManagerAddon) Uninstall() {
+	_, err := addon.communicator.RunCmd(*addon.masterNode, "kubectl delete -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.2.0.yaml")
+	FatalOnError(err)
+	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl -n kube-system delete secret hcloud")
+	FatalOnError(err)
+
+	for _, node := range addon.nodes {
+		_, err := addon.communicator.RunCmd(node, "rm /etc/systemd/system/kubelet.service.d/20-hcloud.conf")
+		FatalOnError(err)
+
+		_, err = addon.communicator.RunCmd(node, "systemctl daemon-reload && systemctl restart kubelet")
+		FatalOnError(err)
+	}
+}

--- a/pkg/addons/addon_hcloud_controller_manager.go
+++ b/pkg/addons/addon_hcloud_controller_manager.go
@@ -1,8 +1,8 @@
 package addons
 
 import (
-	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"fmt"
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
 )
 

--- a/pkg/addons/addon_helm.go
+++ b/pkg/addons/addon_helm.go
@@ -33,7 +33,7 @@ func (addon HelmAddon) Requires() []string {
 
 //Description returns the addons description
 func (addon HelmAddon) Description() string {
-	return "Kuberntes Package Manager"
+	return "Kubernetes Package Manager"
 }
 
 //URL returns the URL of the addons underlying project

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -71,8 +71,8 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 		numProcs++
 		go func(node Node) {
 			manager.eventService.AddEvent(node.Name, "install packages")
-			_, err := manager.nodeCommunicator.RunCmd(node, "wget -cO- https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh | bash -")
-
+			//_, err := manager.nodeCommunicator.RunCmd(node, "wget -cO- https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh | bash -")
+			err := Provision(node, manager.nodeCommunicator, manager.eventService)
 			if err != nil {
 				errChan <- err
 			}

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -72,7 +72,8 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 		go func(node Node) {
 			manager.eventService.AddEvent(node.Name, "install packages")
 			//_, err := manager.nodeCommunicator.RunCmd(node, "wget -cO- https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh | bash -")
-			err := Provision(node, manager.nodeCommunicator, manager.eventService)
+			provisioner := NewNodeProvisioner(node, manager.nodeCommunicator, manager.eventService)
+			err := provisioner.Provision(node, manager.nodeCommunicator, manager.eventService)
 			if err != nil {
 				errChan <- err
 			}

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -2,111 +2,39 @@ package clustermanager
 
 import "strings"
 
-const MAX_ERRORS = 3
+const maxErrors = 3
 
-func Provision(node Node, communicator NodeCommunicator, eventService EventService) error {
-	var err error = nil
+// NodeProvisioner provisions all basic packages to install docker, kubernetes and wireguard
+type NodeProvisioner struct {
+	node         Node
+	communicator NodeCommunicator
+	eventService EventService
+}
+
+// NewNodeProvisioner creates a NodeProvisioner instance
+func NewNodeProvisioner(node Node, communicator NodeCommunicator, eventService EventService) *NodeProvisioner {
+	return &NodeProvisioner{
+		node:         node,
+		communicator: communicator,
+		eventService: eventService,
+	}
+}
+
+// Provision performs all steps to provision a node
+func (provisioner *NodeProvisioner) Provision(node Node, communicator NodeCommunicator, eventService EventService) error {
+	var err error
 	errorCount := 0
 
-	for !PackagesAreInstalled(node, communicator) {
-		aptPreferencesDocker := `
-Package: docker-ce
-Pin: version 17.03.*
-Pin-Priority: 1000
-	`
-		err = communicator.WriteFile(node, "/etc/apt/preferences.d/docker-ce", aptPreferencesDocker, false)
-		if err != nil {
+	for !provisioner.packagesAreInstalled(node, communicator) {
+
+		for err := provisioner.prepareAndInstall(); err != nil; {
 			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
+
+			if errorCount > maxErrors {
+				return err
 			}
-			break
 		}
 
-		eventService.AddEvent(node.Name, "installing transport tools")
-		_, err = communicator.RunCmd(node, "apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
-
-
-		eventService.AddEvent(node.Name, "prepare packages")
-
-		// docker-ce
-		_, err = communicator.RunCmd(node, "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
-
-		// kubernetes
-		_, err = communicator.RunCmd(node, "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
-		_, err = communicator.RunCmd(node, `add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"`)
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
-
-		err = communicator.WriteFile(node, "/etc/apt/sources.list.d/kubernetes.list", `deb http://apt.kubernetes.io/ kubernetes-xenial main`, false)
-		if err != nil {
-			break
-		}
-
-		// wireguard
-		_, err = communicator.RunCmd(node, "add-apt-repository ppa:wireguard/wireguard -y")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			return err
-		}
-
-		eventService.AddEvent(node.Name, "updating packages")
-		_, err = communicator.RunCmd(node, "apt-get update")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
-
-		eventService.AddEvent(node.Name, "installing packages")
-		_, err = communicator.RunCmd(node, "apt-get install -y docker-ce kubelet kubeadm kubectl wireguard linux-headers-$(uname -r) linux-headers-virtual")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
-
-		_, err = communicator.RunCmd(node, "systemctl daemon-reload")
-		if err != nil {
-			errorCount++
-			if errorCount < MAX_ERRORS {
-				continue
-			}
-			break
-		}
 	}
 
 	if err != nil {
@@ -117,7 +45,7 @@ Pin-Priority: 1000
 	return nil
 }
 
-func PackagesAreInstalled(node Node, communicator NodeCommunicator) bool {
+func (provisioner *NodeProvisioner) packagesAreInstalled(node Node, communicator NodeCommunicator) bool {
 	out, err := communicator.RunCmd(node, "type -p kubeadm > /dev/null &> /dev/null; echo $?")
 	if err != nil {
 		return false
@@ -128,4 +56,110 @@ func PackagesAreInstalled(node Node, communicator NodeCommunicator) bool {
 	} else {
 		return false
 	}
+}
+
+func (provisioner *NodeProvisioner) prepareAndInstall() error {
+
+	err := provisioner.installTransportTools()
+	if err != nil {
+		return err
+	}
+	err = provisioner.preparePackages()
+	if err != nil {
+		return err
+	}
+	err = provisioner.updateAndInstall()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *NodeProvisioner) installTransportTools() error {
+
+	provisioner.eventService.AddEvent(provisioner.node.Name, "installing transport tools")
+	_, err := provisioner.communicator.RunCmd(provisioner.node, "apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *NodeProvisioner) preparePackages() error {
+	provisioner.eventService.AddEvent(provisioner.node.Name, "prepare packages")
+
+	err := provisioner.prepareDocker()
+	if err != nil {
+		return err
+	}
+
+	err = provisioner.prepareKubernetes()
+	if err != nil {
+		return err
+	}
+
+	// wireguard
+	_, err = provisioner.communicator.RunCmd(provisioner.node, "add-apt-repository ppa:wireguard/wireguard -y")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+func (provisioner *NodeProvisioner) prepareKubernetes() error {
+	// kubernetes
+	_, err := provisioner.communicator.RunCmd(provisioner.node, "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -")
+	if err != nil {
+		return err
+	}
+
+	err = provisioner.communicator.WriteFile(provisioner.node, "/etc/apt/sources.list.d/kubernetes.list", `deb http://apt.kubernetes.io/ kubernetes-xenial main`, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *NodeProvisioner) prepareDocker() error {
+	// docker-ce
+	aptPreferencesDocker := `
+Package: docker-ce
+Pin: version 17.03.*
+Pin-Priority: 1000
+	`
+	err := provisioner.communicator.WriteFile(provisioner.node, "/etc/apt/preferences.d/docker-ce", aptPreferencesDocker, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = provisioner.communicator.RunCmd(provisioner.node, "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -")
+	if err != nil {
+		return err
+	}
+
+	_, err = provisioner.communicator.RunCmd(provisioner.node, `add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"`)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *NodeProvisioner) updateAndInstall() error {
+	provisioner.eventService.AddEvent(provisioner.node.Name, "updating packages")
+	_, err := provisioner.communicator.RunCmd(provisioner.node, "apt-get update")
+	if err != nil {
+		return err
+	}
+
+	provisioner.eventService.AddEvent(provisioner.node.Name, "installing packages")
+	_, err = provisioner.communicator.RunCmd(provisioner.node, "apt-get install -y docker-ce kubelet kubeadm kubectl wireguard linux-headers-$(uname -r) linux-headers-virtual")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -1,0 +1,131 @@
+package clustermanager
+
+import "strings"
+
+const MAX_ERRORS = 3
+
+func Provision(node Node, communicator NodeCommunicator, eventService EventService) error {
+	var err error = nil
+	errorCount := 0
+
+	for !PackagesAreInstalled(node, communicator) {
+		aptPreferencesDocker := `
+Package: docker-ce
+Pin: version 17.03.*
+Pin-Priority: 1000
+	`
+		err = communicator.WriteFile(node, "/etc/apt/preferences.d/docker-ce", aptPreferencesDocker, false)
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+
+		eventService.AddEvent(node.Name, "installing transport tools")
+		_, err = communicator.RunCmd(node, "apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+
+
+		eventService.AddEvent(node.Name, "prepare packages")
+
+		// docker-ce
+		_, err = communicator.RunCmd(node, "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+
+		// kubernetes
+		_, err = communicator.RunCmd(node, "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+		_, err = communicator.RunCmd(node, `add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"`)
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+
+		err = communicator.WriteFile(node, "/etc/apt/sources.list.d/kubernetes.list", `deb http://apt.kubernetes.io/ kubernetes-xenial main`, false)
+		if err != nil {
+			break
+		}
+
+		// wireguard
+		_, err = communicator.RunCmd(node, "add-apt-repository ppa:wireguard/wireguard -y")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			return err
+		}
+
+		eventService.AddEvent(node.Name, "updating packages")
+		_, err = communicator.RunCmd(node, "apt-get update")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+
+		eventService.AddEvent(node.Name, "installing packages")
+		_, err = communicator.RunCmd(node, "apt-get install -y docker-ce kubelet kubeadm kubectl wireguard linux-headers-$(uname -r) linux-headers-virtual")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+
+		_, err = communicator.RunCmd(node, "systemctl daemon-reload")
+		if err != nil {
+			errorCount++
+			if errorCount < MAX_ERRORS {
+				continue
+			}
+			break
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	eventService.AddEvent(node.Name, "packages installed")
+	return nil
+}
+
+func PackagesAreInstalled(node Node, communicator NodeCommunicator) bool {
+	out, err := communicator.RunCmd(node, "type -p kubeadm > /dev/null &> /dev/null; echo $?")
+	if err != nil {
+		return false
+	}
+
+	if strings.TrimSpace(out) == "0" {
+		return true
+	} else {
+		return false
+	}
+}

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -53,9 +53,8 @@ func (provisioner *NodeProvisioner) packagesAreInstalled(node Node, communicator
 
 	if strings.TrimSpace(out) == "0" {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func (provisioner *NodeProvisioner) prepareAndInstall() error {

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -205,15 +205,17 @@ func (provider *Provider) GetCluster() clustermanager.Cluster {
 func (provider *Provider) GetAdditionalMasterInstallCommands() []clustermanager.NodeCommand {
 
 	return []clustermanager.NodeCommand{
-		{"configure flannel", "kubectl -n kube-system patch ds kube-flannel-ds --type json -p '[{\"op\":\"add\",\"path\":\"/spec/template/spec/tolerations/-\",\"value\":{\"key\":\"node.cloudprovider.kubernetes.io/uninitialized\",\"value\":\"true\",\"effect\":\"NoSchedule\"}}]'"},
-		{"install hcloud integration", fmt.Sprintf("kubectl -n kube-system create secret generic hcloud --from-literal=token=%s", provider.token)},
-		{"deploy cloud controller manager", "kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.0.0.yaml"},
 	}
 }
 
 // MustWait returns true, if we have to wait after creation for some time
 func (provider *Provider) MustWait() bool {
 	return provider.wait
+}
+
+// Token returns the hcloud token
+func (provider *Provider) Token() string {
+	return provider.token
 }
 
 func (provider *Provider) runCreateServer(opts *hcloud.ServerCreateOpts) (*hcloud.ServerCreateResult, error) {

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -204,8 +204,7 @@ func (provider *Provider) GetCluster() clustermanager.Cluster {
 // GetAdditionalMasterInstallCommands
 func (provider *Provider) GetAdditionalMasterInstallCommands() []clustermanager.NodeCommand {
 
-	return []clustermanager.NodeCommand{
-	}
+	return []clustermanager.NodeCommand{}
 }
 
 // MustWait returns true, if we have to wait after creation for some time


### PR DESCRIPTION
This is a double PR which

## 1. moves hcloud-controller-manager to the addons section

So it is not installed by default anymore! This is in favor of #33 and #40. If you are going to use hcloud only nodes, run `hetzner-cloud cluster addon install hcloud-controller-manager -n ...` to install the manager. Note, that adding external workers won't work then.

## 2. moves package install routine from the script into code

This gives the progress bars a better experience and of course, mainly solves problems mentioned in #104 and #89 

