### PR TITLE
makes install routine more failure save

### DIFF
--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -140,7 +140,7 @@ An external server must meet the following requirements:
 
 		FatalOnError(err)
 
-		RenderProgressBars(cluster, coordinator)
+		renderProgressBars(cluster, coordinator)
 		err = clusterManager.ProvisionNodes(nodes)
 		FatalOnError(err)
 

--- a/cmd/cluster_add_worker.go
+++ b/cmd/cluster_add_worker.go
@@ -104,7 +104,7 @@ You can specify the worker server type as in cluster create.`,
 		log.Println("sleep for 30s...")
 		time.Sleep(30 * time.Second)
 
-		RenderProgressBars(cluster, coordinator)
+		renderProgressBars(cluster, coordinator)
 		err = clusterManager.ProvisionNodes(nodes)
 		FatalOnError(err)
 

--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -51,6 +51,7 @@ This tool supports these levels of kubernetes HA:
 	Run:     RunClusterCreate,
 }
 
+// RunClusterCreate executes the cluster creation
 func RunClusterCreate(cmd *cobra.Command, args []string) {
 	workerCount, _ := cmd.Flags().GetInt("worker-count")
 	masterCount, _ := cmd.Flags().GetInt("master-count")
@@ -100,15 +101,16 @@ func RunClusterCreate(cmd *cobra.Command, args []string) {
 	}
 
 	if hetznerProvider.MustWait() {
-		log.Println("sleep for 30s...")
-		time.Sleep(30 * time.Second)
+		log.Println("sleep for 10s...")
+		time.Sleep(5 * time.Second)
 	}
 
 	coordinator := pkg.NewProgressCoordinator()
 
 	clusterManager := clustermanager.NewClusterManager(hetznerProvider, sshClient, coordinator, clusterName, haEnabled, isolatedEtcd, cloudInit, false)
 	cluster := clusterManager.Cluster()
-	RenderProgressBars(&cluster, coordinator)
+	saveCluster(&cluster)
+	renderProgressBars(&cluster, coordinator)
 
 	// provision nodes
 	tries := 0
@@ -167,7 +169,7 @@ func saveCluster(cluster *clustermanager.Cluster) {
 	AppConf.Config.WriteCurrentConfig()
 }
 
-func RenderProgressBars(cluster *clustermanager.Cluster, coordinator *pkg.UiProgressCoordinator) {
+func renderProgressBars(cluster *clustermanager.Cluster, coordinator *pkg.UiProgressCoordinator) {
 	nodes := cluster.Nodes
 	provisionSteps := 5
 	netWorkSetupSteps := 2

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -1,6 +1,9 @@
 package clustermanager
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 const maxErrors = 3
 
@@ -78,7 +81,11 @@ func (provisioner *NodeProvisioner) prepareAndInstall() error {
 func (provisioner *NodeProvisioner) installTransportTools() error {
 
 	provisioner.eventService.AddEvent(provisioner.node.Name, "installing transport tools")
-	_, err := provisioner.communicator.RunCmd(provisioner.node, "apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common")
+	var err error
+	for i := 0; i < 10; i++ {
+		time.Sleep(2 * time.Second)
+		_, err = provisioner.communicator.RunCmd(provisioner.node, "apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common")
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -83,7 +83,7 @@ func (provisioner *NodeProvisioner) installTransportTools() error {
 	provisioner.eventService.AddEvent(provisioner.node.Name, "installing transport tools")
 	var err error
 	for i := 0; i < 10; i++ {
-		time.Sleep(2 * time.Second)
+		time.Sleep(3 * time.Second)
 		_, err = provisioner.communicator.RunCmd(provisioner.node, "apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common")
 	}
 	if err != nil {

--- a/pkg/clustermanager/ssh_communicator.go
+++ b/pkg/clustermanager/ssh_communicator.go
@@ -90,6 +90,7 @@ func (sshComm *SSHCommunicator) newSession(node Node) (*ssh.Session, *ssh.Client
 
 	return session, connection, nil
 }
+
 // WriteFile places a file at a given part from string. Permissions are 0644, or 0755 if executable true
 func (sshComm *SSHCommunicator) WriteFile(node Node, filePath string, content string, executable bool) error {
 	signer, err := sshComm.getPrivateSshKey(node.SSHKeyName)

--- a/pkg/clustermanager/ssh_communicator.go
+++ b/pkg/clustermanager/ssh_communicator.go
@@ -15,11 +15,14 @@ import (
 	"time"
 )
 
+// SSHKey represents a keypair with the paths to the keys
 type SSHKey struct {
 	Name           string `json:"name"`
 	PrivateKeyPath string `json:"private_key_path"`
 	PublicKeyPath  string `json:"public_key_path"`
 }
+
+// SSHCommunicator implements NodeCommunicator as a SSH client
 type SSHCommunicator struct {
 	sshKeys     []SSHKey
 	passPhrases map[string][]byte
@@ -27,6 +30,7 @@ type SSHCommunicator struct {
 
 var _ NodeCommunicator = &SSHCommunicator{}
 
+// NewSSHCommunicator creates an instance of SSHCommunicator
 func NewSSHCommunicator(sshKeys []SSHKey) NodeCommunicator {
 	return &SSHCommunicator{
 		sshKeys:     sshKeys,
@@ -34,6 +38,7 @@ func NewSSHCommunicator(sshKeys []SSHKey) NodeCommunicator {
 	}
 }
 
+// RunCmd runs a bash command on the given node
 func (sshComm *SSHCommunicator) RunCmd(node Node, command string) (output string, err error) {
 	signer, err := sshComm.getPrivateSshKey(node.SSHKeyName)
 
@@ -50,7 +55,7 @@ func (sshComm *SSHCommunicator) RunCmd(node Node, command string) (output string
 	for try := 0; ; try++ {
 		connection, err = ssh.Dial("tcp", node.IPAddress+":22", config)
 		if err != nil {
-			log.Printf("dial failed:%v", err)
+			//log.Printf("dial failed:%v", err)
 			if try > 10 {
 				return "", err
 			}
@@ -63,7 +68,7 @@ func (sshComm *SSHCommunicator) RunCmd(node Node, command string) (output string
 	// log.Println("Connected succeeded!")
 	session, err := connection.NewSession()
 	if err != nil {
-		log.Fatalf("session failed:%v", err)
+		return "", fmt.Errorf("session failed:%v", err)
 	}
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
@@ -73,17 +78,14 @@ func (sshComm *SSHCommunicator) RunCmd(node Node, command string) (output string
 	err = session.Run(command)
 
 	if err != nil {
-		log.Println(stderrBuf.String())
-		log.Printf("> %s", command)
-		log.Println()
-		log.Printf("%s", stdoutBuf.String())
-		return "", fmt.Errorf("run failed:%v", err)
+		return "", fmt.Errorf("run failed\ncommand:%s\nstdout:%s\nstderr:%v", command, stdoutBuf.String(), err)
 	}
 	// log.Println("Command execution succeeded!")
 	session.Close()
 	return stdoutBuf.String(), nil
 }
 
+// WriteFile places a file at a given part from string. Permissions are 0644, or 0755 if executable true
 func (sshComm *SSHCommunicator) WriteFile(node Node, filePath string, content string, executable bool) error {
 	signer, err := sshComm.getPrivateSshKey(node.SSHKeyName)
 
@@ -143,10 +145,12 @@ func (sshComm *SSHCommunicator) WriteFile(node Node, filePath string, content st
 	return nil
 }
 
+// CopyFileOverNode copies a file from a node to another. Does not work with directories.
 func (sshComm *SSHCommunicator) CopyFileOverNode(sourceNode Node, targetNode Node, filePath string) error {
 	return sshComm.TransformFileOverNode(sourceNode, targetNode, filePath, nil)
 }
 
+// TransformFileOverNode works like CopyFileOverNode, with the addition of changing the file contents using a func(string) string function
 func (sshComm *SSHCommunicator) TransformFileOverNode(sourceNode Node, targetNode Node, filePath string, manipulator func(string) string) error {
 	// get the file
 	fileContent, err := sshComm.RunCmd(sourceNode, "cat "+filePath)
@@ -163,7 +167,8 @@ func (sshComm *SSHCommunicator) TransformFileOverNode(sourceNode Node, targetNod
 	return err
 }
 
-func (sshComm *SSHCommunicator) FindPrivateKeyByName(name string) (int, *SSHKey) {
+// findPrivateKeyByName returns a SSH key from its store
+func (sshComm *SSHCommunicator) findPrivateKeyByName(name string) (int, *SSHKey) {
 	index := -1
 	for i, v := range sshComm.sshKeys {
 		if v.Name == name {
@@ -174,8 +179,9 @@ func (sshComm *SSHCommunicator) FindPrivateKeyByName(name string) (int, *SSHKey)
 	return index, nil
 }
 
+// CapturePassphrase asks the user to enter a private keys passphrase
 func (sshComm *SSHCommunicator) CapturePassphrase(sshKeyName string) error {
-	index, privateKey := sshComm.FindPrivateKeyByName(sshKeyName)
+	index, privateKey := sshComm.findPrivateKeyByName(sshKeyName)
 	if index < 0 {
 		return fmt.Errorf("could not find SSH key '%s'", sshKeyName)
 	}
@@ -233,7 +239,7 @@ func (sshComm *SSHCommunicator) isEncrypted(privateKey *SSHKey) (bool, error) {
 }
 
 func (sshComm *SSHCommunicator) getPrivateSshKey(sshKeyName string) (ssh.Signer, error) {
-	index, privateKey := sshComm.FindPrivateKeyByName(sshKeyName)
+	index, privateKey := sshComm.findPrivateKeyByName(sshKeyName)
 	if index < 0 {
 		return nil, fmt.Errorf("cound not find SSH key '%s'", sshKeyName)
 	}

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -261,6 +261,7 @@ func (provider *Provider) actionProgress(action *hcloud.Action) error {
 
 		progress.Start()
 		bar := progress.AddBar(100).AppendCompleted().PrependElapsed()
+		bar.Width = 40
 		bar.Empty = ' '
 
 		for {


### PR DESCRIPTION
this reduces the need to sleep before action after nodes are created from 30 to 5 seconds. The issue is, that the new nodes are randomly failing during `apt` commands the first 30 - 60 seconds after creation, despite they are created in 10 seconds.

The SSH client also behaves more silently in failures, so the progress bars are not bugging.

fix #106