### PR TITLE
Add info about Docker image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ The project source will now be in your `$GOPATH` directory (`$GOPATH/src/github.
 
 If you want to build it yourself later, you can change into the source directory and run `go build` or `go install`.
 
+### Docker image
+
+You can use our [Docker image](https://hub.docker.com/r/xetys/hetzner-kube/) to run `hetzner-kube` without any need to install Go, e.g.
+
+```bash
+$ docker run --rm xetys/hetzner-kube
+```
+```bash
+$ docker run --rm xetys/hetzner-kube ./hetzner-kube cluster list
+```
+
 ## Usage
 
 In your [Hetzner Console](https://console.hetzner.cloud) generate an API token and


### PR DESCRIPTION
I discovered that there is a Docker image for `hetzner-kube`. This is probably worth noting in the README.

P.S.: Can you disclose where the sources for this image are hosted? They don't seem to be on GitHub.