### PR TITLE
persist node CIDR address in config

### DIFF
--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -63,6 +63,7 @@ func (manager *Manager) Cluster() Cluster {
 		IsolatedEtcd:  manager.isolatedEtcd,
 		CloudInitFile: manager.cloudInitFile,
 		SelfHosted:    manager.selfHosted,
+		NodeCIDR:      manager.clusterProvider.GetNodeCidr(),
 	}
 }
 

--- a/pkg/clustermanager/interfaces.go
+++ b/pkg/clustermanager/interfaces.go
@@ -23,5 +23,6 @@ type ClusterProvider interface {
 	GetMasterNode() (*Node, error)
 	GetCluster() Cluster
 	GetAdditionalMasterInstallCommands() []NodeCommand
+	GetNodeCidr() string
 	MustWait() bool
 }

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -222,6 +222,11 @@ func (provider *Provider) GetAdditionalMasterInstallCommands() []clustermanager.
 	return []clustermanager.NodeCommand{}
 }
 
+// GetNodeCidr returns the CIDR to use for nodes in cluster
+func (provider *Provider) GetNodeCidr() string {
+	return provider.nodeCidr
+}
+
 // MustWait returns true, if we have to wait after creation for some time
 func (provider *Provider) MustWait() bool {
 	return provider.wait


### PR DESCRIPTION
Actually in config we do not persist the node CIDR that result as empty string. When we try to create some new node the config miss the CIDR address and the application crash for the missing info.

Cluster already existing should be fixed manually by set the node network CIDR manually in config.

This introduce a breaking change in the `Provider` interface

Closes #163 #148