### PR TITLE
Add cli completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ The project source will now be in your `$GOPATH` directory (`$GOPATH/src/github.
 
 If you want to build it yourself later, you can change into the source directory and run `go build` or `go install`.
 
+### Code completion
+
+To load completion for bash env run
+
+    . <(hetzner-kube completion)
+
+To configure your bash shell to load completions for each session add to your `.bashrc` file:
+
+    # ~/.bashrc or ~/.profile
+    . <(hetzner-kube completion)
+
+Or you can add it to your `bash_completition.d` folder:
+
+    # On linux
+    hetzner-kube completion > /etc/bash_completion.d/hetzner-kube
+    # On OSX with completion installed via brew (`brew intall bash-completion`)
+    hetzner-kube completion > /usr/local/etc/bash_completion.d/hetzner-kube
+
 ## Usage
 
 In your [Hetzner Console](https://console.hetzner.cloud) generate an API token and
@@ -73,6 +91,7 @@ $ hetzner-kube cluster create --name my-cluster --ssh-key my-key
 This will provision a brand new kubernetes cluster in latest version!
 
 For a full list of options that can be passed to the ```cluster create``` command, see the [Cluster Create Guide](docs/cluster-create.md) for more information.
+
 ## HA-clusters
 
 You can build high available clusters with hetzner-kube. Read the [High availability Guide](docs/high-availability.md) for

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -33,14 +33,4 @@ are hopefully coming soon.'`,
 
 func init() {
 	rootCmd.AddCommand(clusterCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// clusterCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// clusterCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -182,5 +182,4 @@ func init() {
 	clusterCmd.AddCommand(clusterAddExternalWorkerCmd)
 	clusterAddExternalWorkerCmd.Flags().StringP("name", "n", "", "Name of the cluster to add the workers to")
 	clusterAddExternalWorkerCmd.Flags().StringP("ip", "i", "", "The IP address of the external node")
-
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,46 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Generates bash completion scripts",
+	Long: `To load completion run
+
+    . <(hetzner-kube completion)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+    # ~/.bashrc or ~/.profile
+    . <(hetzner-kube completion)
+
+Or you can add it to your bash_completition folder:
+
+    hetzner-kube completion > /usr/local/etc/bash_completion.d/hetzner-kube
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenBashCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
This PR introduce auto complete capability on `hetzner-kube` cli, eg:
```
marco@supernova -> hetzner-kube<TAB><TAB>
cluster     completion  context     ssh-key     version
marco@supernova -> hetzner-kube c<TAB><TAB>
cluster     completion  context
marco@supernova -> hetzner-kube clu<TAB>
marco@supernova -> hetzner-kube cluster
marco@supernova -> hetzner-kube cluster <TAB><TAB>
add-external-worker     addon                   delete
list                    remove-external-worker  add-worker
create                  kubeconfig              master-ip
marco@supernova -> hetzner-kube cluster l<TAB>
marco@supernova -> hetzner-kube cluster list
marco@supernova -> hetzner-kube cluster list<ENTER>
NAME        NODES   MASTER IP
mavimo-test 4       xxx.xxx.xx.xxx
```