### PR TITLE
Fix external worker private IP choice

### DIFF
--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -123,14 +123,19 @@ An external server must meet the following requirements:
 		FatalOnError(err)
 		externalNode.Name = hostname
 
+		cidrPrefix := clustermanager.PrivateIPPrefix(cluster.NodeCIDR)
 		// render internal IP address
 		nextNode := 21
-		for _, node := range cluster.Nodes {
-			if !node.IsMaster && !node.IsEtcd {
-				nextNode++
+		outer:
+		for {
+			for _, node := range cluster.Nodes {
+				if node.PrivateIPAddress == fmt.Sprintf("%s.%d", cidrPrefix, nextNode) {
+					nextNode++
+					continue outer
+				}
 			}
+			break
 		}
-		cidrPrefix := clustermanager.PrivateIPPrefix(cluster.NodeCIDR)
 		externalNode.PrivateIPAddress = fmt.Sprintf("%s.%d", cidrPrefix, nextNode)
 		coordinator := pkg.NewProgressCoordinator()
 		hetznerProvider := hetzner.NewHetznerProvider(AppConf.Context, AppConf.Client, AppConf.CurrentContext.Token)

--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -126,7 +126,7 @@ An external server must meet the following requirements:
 		cidrPrefix := clustermanager.PrivateIPPrefix(cluster.NodeCIDR)
 		// render internal IP address
 		nextNode := 21
-		outer:
+	outer:
 		for {
 			for _, node := range cluster.Nodes {
 				if node.PrivateIPAddress == fmt.Sprintf("%s.%d", cidrPrefix, nextNode) {


### PR DESCRIPTION
Just hit a bug while adding external worker `test1-eworker-01` - it uses already taken private IP, and thus alive node `test1-worker-05` goes to `NotReady`
```
cat .hetzner-kube/config.json|jq '.clusters[0].nodes[].name,.clusters[0].nodes[].private_ip_address'
"test1-master-01"
"test1-worker-01"
"test1-worker-02"
"test1-worker-05"
"test1-worker-07"
"test1-eworker-01"
"10.0.1.1"
"10.0.1.21"
"10.0.1.22"
"10.0.1.25"
"10.0.1.27"
"10.0.1.25"
```
And yes, I removed some workers by hand. 

Here is a quick fix to find first free private IP