### PR TITLE
Fix unparam processing issue and execute linting only on go 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+sudo: false
+
+go_import_path: github.com/xetys/hetzner-kube
+
 go:
   - 1.9.x
   - 1.10.x
@@ -15,10 +19,16 @@ before_install:
   - dep ensure
 
 script:
-  - golint cmd/ pkg/
   - go test -v ./...
-  - unused $(go list ./...)
-  - gosimple $(go list ./...)
-  - misspell -error $(git ls-files | grep -v vendor/)
-  - unparam $(go list ./...)
-  - staticcheck $(go list ./...)
+
+jobs:
+  include:
+    - stage: Linting
+      script:
+        - golint $(go list ./...)
+        - unused $(go list ./...)
+        - gosimple $(go list ./...)
+        - misspell -error $(git ls-files | grep -v vendor/)
+        - unparam $(go list ./...)
+        - staticcheck $(go list ./...)
+      go: 1.11.x


### PR DESCRIPTION
 - Move linting only on stable version of golang (since they are linting do not need to be executed for each version).
 - Improve CI definition to be executed without privilege excalation
 - Define project path

Last two point become from the E2E PR, but should be moved here, that I'll rebase.