### PR TITLE
execute E2E tests only if the HETZNER_API_KEY env variable is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
         - make test-all
         - make cleanup
       go: 1.11.x
+      if: env(HETZNER_API_KEY) IS present
 
     - stage: Build
       script:


### PR DESCRIPTION
Since travis do not expose secret env variable to external repo we need to skip E2E test from branch that are outside repo, otherwise CI will always be false.