### PR TITLE
generate wireguard keypairs from go code instead of SSH in a node

### DIFF
--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -101,18 +101,19 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 //SetupEncryptedNetwork setups an encrypted virtual network using wireguard
 // modifies the state of manager.Nodes
 func (manager *Manager) SetupEncryptedNetwork() error {
-	nodes := manager.nodes
-	// render a public/private key pair
-	keyPairs, err := manager.GenerateKeyPairs(nodes[0], len(nodes))
-	if err != nil {
-		return fmt.Errorf("unable to setup encrypted network: %v", err)
-	}
+	var err error
+	var keyPair WgKeyPair
 
-	for i, keyPair := range keyPairs {
+	for i := range manager.nodes {
+		keyPair, err = GenerateKeyPair()
+		if err != nil {
+			return fmt.Errorf("unable to setup encrypted network: %v", err)
+		}
+
 		manager.nodes[i].WireGuardKeyPair = keyPair
 	}
 
-	nodes = manager.nodes
+	nodes := manager.nodes
 
 	// for each node, get specific IP and install it on node
 	errChan := make(chan error)

--- a/pkg/clustermanager/wireguard.go
+++ b/pkg/clustermanager/wireguard.go
@@ -1,35 +1,18 @@
 package clustermanager
 
 import (
-	"encoding/json"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"strings"
+
+	"golang.org/x/crypto/curve25519"
 )
 
 //WgKeyPair containse key pairs
 type WgKeyPair struct {
 	Private string `json:"private"`
 	Public  string `json:"public"`
-}
-
-//GenerateKeyPairs generate key pairs
-func (manager *Manager) GenerateKeyPairs(node Node, count int) ([]WgKeyPair, error) {
-	genKeyPairs := fmt.Sprintf(`echo "[" ;for i in {1..%d}; do pk=$(wg genkey); pubk=$(echo $pk | wg pubkey);echo "{\"private\":\"$pk\",\"public\":\"$pubk\"},"; done; echo "]";`, count)
-	// gives an invalid JSON back
-	o, err := manager.nodeCommunicator.RunCmd(node, genKeyPairs)
-	if err != nil {
-		return []WgKeyPair{}, fmt.Errorf("unable to generate a key pairs: %v", err)
-	}
-	o = o[0:len(o)-4] + "]"
-	// now it's a valid json
-
-	var keyPairs []WgKeyPair
-	err = json.Unmarshal([]byte(o), &keyPairs)
-	if err != nil {
-		return []WgKeyPair{}, fmt.Errorf("unable to json decode key pairs: %v", err)
-	}
-
-	return keyPairs, nil
 }
 
 //GenerateWireguardConf generate wireguard configuration file
@@ -66,4 +49,26 @@ Endpoint = %s:51820
 // PrivateIPPrefix extracts the first 3 digits of an IPv4 address
 func PrivateIPPrefix(ip string) string {
 	return strings.Join(strings.Split(ip, ".")[:3], ".")
+}
+
+// GenerateKeyPair create a key-pair used to instantiate a wireguard connection
+// Code is redacted from https://github.com/WireGuard/wireguard-go/blob/1c025570139f614f2083b935e2c58d5dbf199c2f/noise-helpers.go
+func GenerateKeyPair() (WgKeyPair, error) {
+	var publicKey [32]byte
+	var privateKey [32]byte
+	_, err := rand.Reader.Read(privateKey[:])
+	if err != nil {
+		return WgKeyPair{}, fmt.Errorf("unable to generate a private key: %v", err)
+	}
+
+	privateKey[0] &= 248
+	privateKey[31] &= 127
+	privateKey[31] |= 64
+
+	curve25519.ScalarBaseMult(&publicKey, &privateKey)
+
+	return WgKeyPair{
+		Private: base64.StdEncoding.EncodeToString(privateKey[:]),
+		Public:  base64.StdEncoding.EncodeToString(publicKey[:]),
+	}, nil
 }

--- a/pkg/clustermanager/wireguard_test.go
+++ b/pkg/clustermanager/wireguard_test.go
@@ -1,11 +1,16 @@
-package clustermanager
+package clustermanager_test
 
-import "testing"
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/xetys/hetzner-kube/pkg/clustermanager"
+)
 
 func TestGenerateWireguardConf(t *testing.T) {
-	nodes := []Node{
-		{Name: "node1", IPAddress: "1.1.1.1", PrivateIPAddress: "10.0.0.1", WireGuardKeyPair: WgKeyPair{Private: "node1priv", Public: "node1pub"}},
-		{Name: "node2", IPAddress: "1.1.1.2", PrivateIPAddress: "10.0.0.2", WireGuardKeyPair: WgKeyPair{Private: "node2priv", Public: "node2pub"}},
+	nodes := []clustermanager.Node{
+		{Name: "node1", IPAddress: "1.1.1.1", PrivateIPAddress: "10.0.0.1", WireGuardKeyPair: clustermanager.WgKeyPair{Private: "node1priv", Public: "node1pub"}},
+		{Name: "node2", IPAddress: "1.1.1.2", PrivateIPAddress: "10.0.0.2", WireGuardKeyPair: clustermanager.WgKeyPair{Private: "node2priv", Public: "node2pub"}},
 	}
 
 	expectedConf := `[Interface]
@@ -20,10 +25,43 @@ AllowedIps = 10.0.0.1/32
 Endpoint = 1.1.1.1:51820
 `
 
-	generatedConf := GenerateWireguardConf(nodes[1], nodes)
+	generatedConf := clustermanager.GenerateWireguardConf(nodes[1], nodes)
 
 	if generatedConf != expectedConf {
 		t.Errorf("The file was not rendered as expected\n%s\n\n", generatedConf)
 	}
 
+}
+
+func TestGenerateKeyPair(t *testing.T) {
+	wgKey, err := clustermanager.GenerateKeyPair()
+	if err != nil {
+		t.Errorf("Unable to generate keypairs")
+	}
+
+	if wgKey.Private == "" {
+		t.Errorf("Private key is not correctly set")
+	}
+
+	if wgKey.Public == "" {
+		t.Errorf("Public key is not correctly set")
+	}
+
+	privateBytes, err := base64.StdEncoding.DecodeString(wgKey.Private)
+	if err != nil {
+		t.Errorf("Private key is not correctly Base64 encoded")
+	}
+
+	if len(privateBytes) != 32 {
+		t.Errorf("Private key is not 32 bytes len")
+	}
+
+	publicBytes, err := base64.StdEncoding.DecodeString(wgKey.Public)
+	if err != nil {
+		t.Errorf("Public key is not correctly Base64 encoded")
+	}
+
+	if len(publicBytes) != 32 {
+		t.Errorf("Public key is not 32 bytes len")
+	}
 }


### PR DESCRIPTION
Closes #136 