### PR TITLE
Add test for IP prefix & handled wrong IP

### DIFF
--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -124,7 +124,11 @@ An external server must meet the following requirements:
 		FatalOnError(err)
 		externalNode.Name = hostname
 
-		cidrPrefix := clustermanager.PrivateIPPrefix(cluster.NodeCIDR)
+		cidrPrefix, err := clustermanager.PrivateIPPrefix(cluster.NodeCIDR)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		// render internal IP address
 		nextNode := 21
 	outer:

--- a/pkg/clustermanager/wireguard.go
+++ b/pkg/clustermanager/wireguard.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"strings"
 
 	"golang.org/x/crypto/curve25519"
@@ -47,8 +48,17 @@ Endpoint = %s:51820
 }
 
 // PrivateIPPrefix extracts the first 3 digits of an IPv4 address
-func PrivateIPPrefix(ip string) string {
-	return strings.Join(strings.Split(ip, ".")[:3], ".")
+func PrivateIPPrefix(ip string) (string, error) {
+	ipAddress := net.ParseIP(ip)
+	if ipAddress == nil {
+		return "", fmt.Errorf("unable to parse ip %q", ip)
+	}
+	ipAddress = ipAddress.To4()
+	if ipAddress == nil {
+		return "", fmt.Errorf("unable to convert ip %q to IPv4s", ip)
+	}
+
+	return strings.Join(strings.Split(ipAddress.String(), ".")[:3], "."), nil
 }
 
 // GenerateKeyPair create a key-pair used to instantiate a wireguard connection

--- a/pkg/clustermanager/wireguard_test.go
+++ b/pkg/clustermanager/wireguard_test.go
@@ -87,9 +87,29 @@ func TestPrivateIPPrefix(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(fmt.Sprintf("testing IP: %s", tC.source), func(t *testing.T) {
-			generated := clustermanager.PrivateIPPrefix(tC.source)
+			generated, err := clustermanager.PrivateIPPrefix(tC.source)
+			if err != nil {
+				t.Errorf("Unexpected error on parsing valid IP\nParsing IP: %s\nExpected: %s\nGenerated: %s\n", tC.source, tC.expected, generated)
+			}
+
 			if tC.expected != generated {
 				t.Errorf("\nParsing IP: %s\nExpected: %s\nGenerated: %s\n", tC.source, tC.expected, generated)
+			}
+		})
+	}
+}
+
+func TestPrivateIPPrefixWithWrongIpAddress(t *testing.T) {
+	testCases := []struct{ source string }{
+		{source: "10.5.3"},
+		{source: "10.20.30.6000"},
+		{source: "250.251.252.253.254"},
+	}
+	for _, tC := range testCases {
+		t.Run(fmt.Sprintf("testing IP: %s", tC.source), func(t *testing.T) {
+			_, err := clustermanager.PrivateIPPrefix(tC.source)
+			if err == nil {
+				t.Errorf("we expect an error on parsing invalid IP %q", tC.source)
 			}
 		})
 	}

--- a/pkg/clustermanager/wireguard_test.go
+++ b/pkg/clustermanager/wireguard_test.go
@@ -2,6 +2,7 @@ package clustermanager_test
 
 import (
 	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
@@ -63,5 +64,33 @@ func TestGenerateKeyPair(t *testing.T) {
 
 	if len(publicBytes) != 32 {
 		t.Errorf("Public key is not 32 bytes len")
+	}
+}
+
+func TestPrivateIPPrefix(t *testing.T) {
+	testCases := []struct {
+		source   string
+		expected string
+	}{
+		{
+			source:   "10.5.3.6",
+			expected: "10.5.3",
+		},
+		{
+			source:   "10.20.30.60",
+			expected: "10.20.30",
+		},
+		{
+			source:   "250.251.252.253",
+			expected: "250.251.252",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(fmt.Sprintf("testing IP: %s", tC.source), func(t *testing.T) {
+			generated := clustermanager.PrivateIPPrefix(tC.source)
+			if tC.expected != generated {
+				t.Errorf("\nParsing IP: %s\nExpected: %s\nGenerated: %s\n", tC.source, tC.expected, generated)
+			}
+		})
 	}
 }

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -102,7 +102,11 @@ func (provider *Provider) CreateNodes(suffix string, template clustermanager.Nod
 				privateIPLastBlock += 10
 			}
 		}
-		cidrPrefix := clustermanager.PrivateIPPrefix(provider.nodeCidr)
+		cidrPrefix, err := clustermanager.PrivateIPPrefix(provider.nodeCidr)
+		if err != nil {
+			return nil, err
+		}
+
 		privateIPAddress := fmt.Sprintf("%s.%d", cidrPrefix, privateIPLastBlock)
 
 		node := clustermanager.Node{


### PR DESCRIPTION
This should be merged after #210 

 - Refactor method `PrivateIPPrefix` that can be generate error if the source string is not a valid IP (since we are  just slicing it without any validation) 
 - Add test for method `PrivateIPPrefix`