### PR TITLE
execute build in CI only for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ jobs:
       script:
         - echo "Build binary & deploying to GitHub releases ..."
         - make build
-      go: 1.10.x
+      go: 1.11.x
+      if: tag IS present
 
 deploy:
   provider: releases


### PR DESCRIPTION
Fixed build to be executed on golang 1.11.x and only when a tag is available