### PR TITLE
disable E2E on fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,10 @@ jobs:
         - make test-all
         - make cleanup
       go: 1.11.x
-      if: env(HETZNER_API_KEY) IS present
+      if: fork = false
 
     - stage: Build
       script:
-        - echo "Build binary & deploying to GitHub releases ..."
         - make build
       go: 1.11.x
       if: tag IS present


### PR DESCRIPTION
Since fork are not allowed to use encrypted var we should sto to run E2E using it