### PR TITLE
Remove unuseful comments

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -188,6 +188,7 @@ An external server must meet the following requirements:
 
 func init() {
 	clusterCmd.AddCommand(clusterAddExternalWorkerCmd)
+
 	clusterAddExternalWorkerCmd.Flags().StringP("name", "n", "", "Name of the cluster to add the workers to")
 	clusterAddExternalWorkerCmd.Flags().StringP("ip", "i", "", "The IP address of the external node")
 }

--- a/cmd/cluster_add_worker.go
+++ b/cmd/cluster_add_worker.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_add_worker.go
+++ b/cmd/cluster_add_worker.go
@@ -142,6 +142,7 @@ You can specify the worker server type as in cluster create.`,
 
 func init() {
 	clusterCmd.AddCommand(clusterAddWorkerCmd)
+
 	clusterAddWorkerCmd.Flags().StringP("name", "", "", "Name of the cluster to add the workers to")
 	clusterAddWorkerCmd.Flags().String("worker-server-type", "cx11", "Server type used of workers")
 	clusterAddWorkerCmd.Flags().IntP("nodes", "n", 2, "Number of nodes for the cluster")

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -34,8 +34,8 @@ var clusterAddonCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(clusterAddonCmd)
-
 }
+
 func validateAddonSubCommand(cmd *cobra.Command, args []string) error {
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {

--- a/cmd/cluster_addon_install.go
+++ b/cmd/cluster_addon_install.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_addon_install.go
+++ b/cmd/cluster_addon_install.go
@@ -52,5 +52,6 @@ var clusterAddonInstallCmd = &cobra.Command{
 
 func init() {
 	clusterAddonCmd.AddCommand(clusterAddonInstallCmd)
+
 	clusterAddonInstallCmd.Flags().StringP("name", "n", "", "Name of the cluster")
 }

--- a/cmd/cluster_addon_list.go
+++ b/cmd/cluster_addon_list.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_addon_uninstall.go
+++ b/cmd/cluster_addon_uninstall.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_addon_uninstall.go
+++ b/cmd/cluster_addon_uninstall.go
@@ -52,5 +52,6 @@ var clusterAddonUninstallCmd = &cobra.Command{
 
 func init() {
 	clusterAddonCmd.AddCommand(clusterAddonUninstallCmd)
+
 	clusterAddonUninstallCmd.Flags().StringP("name", "n", "", "Name of the cluster")
 }

--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_delete.go
+++ b/cmd/cluster_delete.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_delete.go
+++ b/cmd/cluster_delete.go
@@ -78,15 +78,6 @@ var clusterDeleteCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(clusterDeleteCmd)
+
 	clusterDeleteCmd.Flags().StringP("name", "n", "", "Name of the cluster to delete")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// clusterDeleteCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// clusterDeleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -117,14 +117,4 @@ func init() {
 	clusterKubeconfigCmd.Flags().BoolP("print", "p", false, "prints output to stdout")
 	clusterKubeconfigCmd.Flags().BoolP("backup", "b", false, "saves existing config")
 	clusterKubeconfigCmd.Flags().BoolP("force", "f", false, "don't ask to overwrite")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// clusterKubeconfigCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// clusterKubeconfigCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -51,14 +51,4 @@ var clusterListCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(clusterListCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// clusterListCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// clusterListCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cluster_master_ip.go
+++ b/cmd/cluster_master_ip.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_remove_external_worker.go
+++ b/cmd/cluster_remove_external_worker.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/cluster_remove_external_worker.go
+++ b/cmd/cluster_remove_external_worker.go
@@ -85,7 +85,7 @@ var clusterRemoveExternalWorkerCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(clusterRemoveExternalWorkerCmd)
+
 	clusterRemoveExternalWorkerCmd.Flags().StringP("name", "n", "", "Name of the cluster where to remove the worker")
 	clusterRemoveExternalWorkerCmd.Flags().StringP("ip", "i", "", "The IP address of the external node")
-
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,7 +21,7 @@ var DefaultConfigPath string
 // AppConf is the default configuration from the local system.
 var AppConf = NewAppConfig()
 
-//AppSSHClient is the SSH client
+// AppSSHClient is the SSH client
 type AppSSHClient struct {
 }
 
@@ -45,7 +45,7 @@ func NewAppConfig() AppConfig {
 	return appConf
 }
 
-//WriteCurrentConfig write the configuration to file
+// WriteCurrentConfig write the configuration to file
 func (config HetznerConfig) WriteCurrentConfig() {
 	configFileName := filepath.Join(DefaultConfigPath, "config.json")
 	configJSON, err := json.Marshal(&config)
@@ -61,17 +61,17 @@ func (config HetznerConfig) WriteCurrentConfig() {
 	}
 }
 
-//AddContext add context to config
+// AddContext add context to config
 func (config *HetznerConfig) AddContext(context HetznerContext) {
 	config.Contexts = append(config.Contexts, context)
 }
 
-//AddSSHKey add a new SSH key to config
+// AddSSHKey add a new SSH key to config
 func (config *HetznerConfig) AddSSHKey(key clustermanager.SSHKey) {
 	config.SSHKeys = append(config.SSHKeys, key)
 }
 
-//DeleteSSHKey remove the SSH key from config
+// DeleteSSHKey remove the SSH key from config
 func (config *HetznerConfig) DeleteSSHKey(name string) error {
 
 	index, err := config.FindSSHKeyByName(name)
@@ -84,7 +84,7 @@ func (config *HetznerConfig) DeleteSSHKey(name string) error {
 	return nil
 }
 
-//FindSSHKeyByName find a SSH key in config by name
+// FindSSHKeyByName find a SSH key in config by name
 func (config *HetznerConfig) FindSSHKeyByName(name string) (int, error) {
 	for i, v := range config.SSHKeys {
 		if v.Name == name {
@@ -95,7 +95,7 @@ func (config *HetznerConfig) FindSSHKeyByName(name string) (int, error) {
 	return -1, fmt.Errorf("unable to find '%s' SSH key", name)
 }
 
-//AddCluster add a cluster in config
+// AddCluster add a cluster in config
 func (config *HetznerConfig) AddCluster(cluster clustermanager.Cluster) {
 	for i, v := range config.Clusters {
 		if v.Name == cluster.Name {
@@ -107,7 +107,7 @@ func (config *HetznerConfig) AddCluster(cluster clustermanager.Cluster) {
 	config.Clusters = append(config.Clusters, cluster)
 }
 
-//DeleteCluster remove cluster from config
+// DeleteCluster remove cluster from config
 func (config *HetznerConfig) DeleteCluster(name string) error {
 
 	index, _ := config.FindClusterByName(name)
@@ -121,7 +121,7 @@ func (config *HetznerConfig) DeleteCluster(name string) error {
 	return nil
 }
 
-//FindClusterByName find a cluster by name in config
+// FindClusterByName find a cluster by name in config
 func (config *HetznerConfig) FindClusterByName(name string) (int, *clustermanager.Cluster) {
 	for i, cluster := range config.Clusters {
 		if cluster.Name == name {
@@ -132,7 +132,7 @@ func (config *HetznerConfig) FindClusterByName(name string) (int, *clustermanage
 	return -1, nil
 }
 
-//SwitchContextByName switch to context with a specific name in app
+// SwitchContextByName switch to context with a specific name in app
 func (app *AppConfig) SwitchContextByName(name string) error {
 	ctx, err := app.FindContextByName(name)
 
@@ -152,7 +152,7 @@ func (app *AppConfig) SwitchContextByName(name string) error {
 	return nil
 }
 
-//FindContextByName find a context using name
+// FindContextByName find a context using name
 func (app *AppConfig) FindContextByName(name string) (*HetznerContext, error) {
 
 	for _, ctx := range app.Config.Contexts {

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -29,14 +29,4 @@ var contextCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(contextCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// contextCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// contextCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/context_add.go
+++ b/cmd/context_add.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/context_current.go
+++ b/cmd/context_current.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/context_current.go
+++ b/cmd/context_current.go
@@ -31,14 +31,4 @@ var currentCmd = &cobra.Command{
 
 func init() {
 	contextCmd.AddCommand(currentCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// currentCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// currentCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/context_delete.go
+++ b/cmd/context_delete.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/context_delete.go
+++ b/cmd/context_delete.go
@@ -48,14 +48,4 @@ var contextDeleteCmd = &cobra.Command{
 
 func init() {
 	contextCmd.AddCommand(contextDeleteCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/context_list.go
+++ b/cmd/context_list.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/context_list.go
+++ b/cmd/context_list.go
@@ -44,14 +44,4 @@ var listCmd = &cobra.Command{
 
 func init() {
 	contextCmd.AddCommand(listCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/context_use.go
+++ b/cmd/context_use.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/context_use.go
+++ b/cmd/context_use.go
@@ -39,14 +39,4 @@ var useCmd = &cobra.Command{
 
 func init() {
 	contextCmd.AddCommand(useCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// useCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// useCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/ssh_key.go
+++ b/cmd/ssh_key.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/ssh_key.go
+++ b/cmd/ssh_key.go
@@ -32,15 +32,6 @@ Note, that the private key never gets uploaded anywhere. The path is used to con
 
 func init() {
 	rootCmd.AddCommand(sshKeyCmd)
+
 	sshKeyCmd.Flags().StringP("name", "n", "", "")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// sshKeyCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// sshKeyCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/ssh_key_add.go
+++ b/cmd/ssh_key_add.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/ssh_key_add.go
+++ b/cmd/ssh_key_add.go
@@ -178,17 +178,8 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 
 func init() {
 	sshKeyCmd.AddCommand(sshKeyAddCmd)
+
 	sshKeyAddCmd.Flags().StringP("name", "n", "", "the name of the key")
 	sshKeyAddCmd.Flags().String("private-key-path", "~/.ssh/id_rsa", "the path to the private key")
 	sshKeyAddCmd.Flags().String("public-key-path", "~/.ssh/id_rsa.pub", "the path to the public key")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// sshKeyAddCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// sshKeyAddCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/ssh_key_delete.go
+++ b/cmd/ssh_key_delete.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/ssh_key_delete.go
+++ b/cmd/ssh_key_delete.go
@@ -65,15 +65,6 @@ func validateSHHKeyDeleteFlags(cmd *cobra.Command, args []string) error {
 }
 func init() {
 	sshKeyCmd.AddCommand(sshKeyDeleteCmd)
+
 	sshKeyDeleteCmd.Flags().StringP("name", "n", "", "Name of the ssh-key")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// sshKeyDeleteCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// sshKeyDeleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/ssh_key_list.go
+++ b/cmd/ssh_key_list.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/cmd/ssh_key_list.go
+++ b/cmd/ssh_key_list.go
@@ -49,14 +49,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	sshKeyCmd.AddCommand(sshKeyListCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// sshKeyListCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// sshKeyListCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -7,20 +7,20 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//HetznerContext declare the hetzner cloud context
+// HetznerContext declare the hetzner cloud context
 type HetznerContext struct {
 	Token string `json:"token"`
 	Name  string `json:"name"`
 }
 
-//SSHKey (deprecated)
+// SSHKey (deprecated)
 type SSHKey struct {
 	Name           string `json:"name"`
 	PrivateKeyPath string `json:"private_key_path"`
 	PublicKeyPath  string `json:"public_key_path"`
 }
 
-//HetznerConfig define the hetzner cloud provider config
+// HetznerConfig define the hetzner cloud provider config
 type HetznerConfig struct {
 	ActiveContextName string                   `json:"active_context_name"`
 	Contexts          []HetznerContext         `json:"contexts"`
@@ -28,7 +28,7 @@ type HetznerConfig struct {
 	Clusters          []clustermanager.Cluster `json:"clusters"`
 }
 
-//AppConfig define the application configuration
+// AppConfig define the application configuration
 type AppConfig struct {
 	Client         *hcloud.Client
 	Context        context.Context

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -11,7 +11,7 @@ func randomName() string {
 	return fmt.Sprintf("%s-%s%s", randomdata.Adjective(), randomdata.Noun(), randomdata.Adjective())
 }
 
-//FatalOnError is an helper function to transform error to fatl
+// FatalOnError is an helper function to transform error to fatl
 func FatalOnError(err error) {
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package main
 
 import "github.com/xetys/hetzner-kube/cmd"

--- a/pkg/addons/addon_cert_manager.go
+++ b/pkg/addons/addon_cert_manager.go
@@ -6,7 +6,7 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//CertmanagerAddon installs cert-manager
+// CertmanagerAddon installs cert-manager
 type CertmanagerAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
@@ -23,27 +23,27 @@ func init() {
 	addAddon(NewCertmanagerAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon *CertmanagerAddon) Name() string {
 	return "cert-manager"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon *CertmanagerAddon) Requires() []string {
 	return []string{"helm"}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon *CertmanagerAddon) Description() string {
 	return "Auto-TLS provisioning & management"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon *CertmanagerAddon) URL() string {
 	return "https://github.com/jetstack/cert-manager"
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon *CertmanagerAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --name cert-manager --namespace ingress stable/cert-manager")
@@ -51,7 +51,7 @@ func (addon *CertmanagerAddon) Install(args ...string) {
 	log.Println("cert-manager installed")
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon *CertmanagerAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm delete --purge cert-manager")

--- a/pkg/addons/addon_docker_registry.go
+++ b/pkg/addons/addon_docker_registry.go
@@ -6,7 +6,7 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//DockerregistryAddon installs a private container registry
+// DockerregistryAddon installs a private container registry
 type DockerregistryAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
@@ -23,27 +23,27 @@ func init() {
 	addAddon(NewDockerregistryAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon *DockerregistryAddon) Name() string {
 	return "docker-registry"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon *DockerregistryAddon) Requires() []string {
 	return []string{"helm"}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon *DockerregistryAddon) Description() string {
 	return "Private container registry"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon *DockerregistryAddon) URL() string {
 	return "https://github.com/kubernetes/charts/tree/master/stable/docker-registry"
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon *DockerregistryAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --set persistence.enabled=true stable/docker-registry")
@@ -51,7 +51,7 @@ func (addon *DockerregistryAddon) Install(args ...string) {
 	log.Println("docker-registry installed")
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon DockerregistryAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm delete --purge `helm list | grep docker-registry  | awk '{print $1;}'`")

--- a/pkg/addons/addon_hcloud_controller_manager.go
+++ b/pkg/addons/addon_hcloud_controller_manager.go
@@ -31,27 +31,27 @@ func init() {
 	addAddon(NewHCloudControllerManagerAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon *HCloudControllerManagerAddon) Name() string {
 	return "hcloud-controller-manager"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon *HCloudControllerManagerAddon) Requires() []string {
 	return []string{}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon *HCloudControllerManagerAddon) Description() string {
 	return "Hetzner Cloud official cloud controller manager"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon *HCloudControllerManagerAddon) URL() string {
 	return "https://github.com/hetznercloud/hcloud-cloud-controller-manager"
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon *HCloudControllerManagerAddon) Install(args ...string) {
 	// set external cloud provider
 	config := `
@@ -74,7 +74,7 @@ Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
 	FatalOnError(err)
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon *HCloudControllerManagerAddon) Uninstall() {
 	_, err := addon.communicator.RunCmd(*addon.masterNode, "kubectl delete -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.2.0.yaml")
 	FatalOnError(err)

--- a/pkg/addons/addon_helm.go
+++ b/pkg/addons/addon_helm.go
@@ -6,13 +6,13 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//HelmAddon installs helm
+// HelmAddon installs helm
 type HelmAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
 }
 
-//NewHelmAddon installs helm to the cluster
+// NewHelmAddon installs helm to the cluster
 func NewHelmAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, _ := provider.GetMasterNode()
 	return HelmAddon{masterNode: masterNode, communicator: communicator}
@@ -22,27 +22,27 @@ func init() {
 	addAddon(NewHelmAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon HelmAddon) Name() string {
 	return "helm"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon HelmAddon) Requires() []string {
 	return []string{}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon HelmAddon) Description() string {
 	return "Kubernetes Package Manager"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon HelmAddon) URL() string {
 	return "https://helm.sh"
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon HelmAddon) Install(args ...string) {
 
 	node := *addon.masterNode
@@ -78,7 +78,7 @@ subjects:
 	fmt.Println("Helm installed")
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon HelmAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm reset --force")

--- a/pkg/addons/addon_ingress.go
+++ b/pkg/addons/addon_ingress.go
@@ -6,13 +6,13 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//IngressAddon installs an ingress controller
+// IngressAddon installs an ingress controller
 type IngressAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
 }
 
-//NewIngressAddon creates an addon to install a nginx ingress controller
+// NewIngressAddon creates an addon to install a nginx ingress controller
 func NewIngressAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, err := provider.GetMasterNode()
 	FatalOnError(err)
@@ -23,27 +23,27 @@ func init() {
 	addAddon(NewIngressAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon *IngressAddon) Name() string {
 	return "nginx-ingress-controller"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon *IngressAddon) Requires() []string {
 	return []string{"helm"}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon *IngressAddon) Description() string {
 	return "an ingress based load balancer for K8S"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon *IngressAddon) URL() string {
 	return ""
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon *IngressAddon) Install(args ...string) {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm install --name ingress --namespace ingress --set rbac.create=true,controller.kind=DaemonSet,controller.service.type=ClusterIP,controller.hostNetwork=true stable/nginx-ingress")
@@ -51,7 +51,7 @@ func (addon *IngressAddon) Install(args ...string) {
 	log.Println("nginx ingress installed")
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon *IngressAddon) Uninstall() {
 	node := *addon.masterNode
 	_, err := addon.communicator.RunCmd(node, "helm delete --purge ingress")

--- a/pkg/addons/addon_openebs.go
+++ b/pkg/addons/addon_openebs.go
@@ -6,13 +6,13 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//OpenEBSAddon installs OpenEBS
+// OpenEBSAddon installs OpenEBS
 type OpenEBSAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
 }
 
-//NewOpenEBSAddon creates an addon which installs OpenEBS
+// NewOpenEBSAddon creates an addon which installs OpenEBS
 func NewOpenEBSAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, _ := provider.GetMasterNode()
 	return &OpenEBSAddon{masterNode: masterNode, communicator: communicator}
@@ -22,27 +22,27 @@ func init() {
 	addAddon(NewOpenEBSAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon OpenEBSAddon) Name() string {
 	return "openebs"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon OpenEBSAddon) Requires() []string {
 	return []string{}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon OpenEBSAddon) Description() string {
 	return "Simple scalable block storage provider"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon OpenEBSAddon) URL() string {
 	return "https://openebs.io/"
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon OpenEBSAddon) Install(args ...string) {
 	node := *addon.masterNode
 
@@ -68,7 +68,7 @@ parameters:
 	fmt.Println("OpenEBS installed")
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon OpenEBSAddon) Uninstall() {
 	node := *addon.masterNode
 

--- a/pkg/addons/addon_prometheus.go
+++ b/pkg/addons/addon_prometheus.go
@@ -7,7 +7,7 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/hetzner"
 )
 
-//PrometheusAddon provides cluster monitoring using prometheus operator
+// PrometheusAddon provides cluster monitoring using prometheus operator
 type PrometheusAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
@@ -15,7 +15,7 @@ type PrometheusAddon struct {
 	provider     *hetzner.Provider
 }
 
-//NewPrometheusAddon create a new prometheus addon
+// NewPrometheusAddon create a new prometheus addon
 func NewPrometheusAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, err := provider.GetMasterNode()
 	FatalOnError(err)
@@ -31,22 +31,22 @@ func init() {
 	addAddon(NewPrometheusAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon *PrometheusAddon) Name() string {
 	return "kube-prometheus"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon *PrometheusAddon) Requires() []string {
 	return []string{}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon *PrometheusAddon) Description() string {
 	return "CoreOS prometheus operator /w cluster monitoring"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon *PrometheusAddon) URL() string {
 	return "https://github.com/coreos/prometheus-operator"
 }

--- a/pkg/addons/addon_rook.go
+++ b/pkg/addons/addon_rook.go
@@ -7,14 +7,14 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//RookAddon installs rook
+// RookAddon installs rook
 type RookAddon struct {
 	masterNode   *clustermanager.Node
 	communicator clustermanager.NodeCommunicator
 	nodes        []clustermanager.Node
 }
 
-//NewRookAddon creates an addon which install rook
+// NewRookAddon creates an addon which install rook
 func NewRookAddon(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon {
 	masterNode, _ := provider.GetMasterNode()
 	return &RookAddon{masterNode: masterNode, communicator: communicator, nodes: provider.GetAllNodes()}
@@ -24,27 +24,27 @@ func init() {
 	addAddon(NewRookAddon)
 }
 
-//Name returns the addons name
+// Name returns the addons name
 func (addon RookAddon) Name() string {
 	return "rook"
 }
 
-//Requires returns a slice with the name of required addons
+// Requires returns a slice with the name of required addons
 func (addon RookAddon) Requires() []string {
 	return []string{}
 }
 
-//Description returns the addons description
+// Description returns the addons description
 func (addon RookAddon) Description() string {
 	return "File, Block and Object Storage provider"
 }
 
-//URL returns the URL of the addons underlying project
+// URL returns the URL of the addons underlying project
 func (addon RookAddon) URL() string {
 	return "https://rook.io"
 }
 
-//Install performs all steps to install the addon
+// Install performs all steps to install the addon
 func (addon RookAddon) Install(args ...string) {
 	node := *addon.masterNode
 
@@ -72,7 +72,7 @@ func (addon RookAddon) Install(args ...string) {
 	fmt.Println("Rook installed")
 }
 
-//Uninstall performs all steps to remove the addon
+// Uninstall performs all steps to remove the addon
 func (addon RookAddon) Uninstall() {
 	node := *addon.masterNode
 	addon.communicator.RunCmd(node, "kubectl delete -n rook pool replicapool")

--- a/pkg/addons/cluster_addon.go
+++ b/pkg/addons/cluster_addon.go
@@ -2,7 +2,7 @@ package addons
 
 import "github.com/xetys/hetzner-kube/pkg/clustermanager"
 
-//ClusterAddon describes what functions a cluster addon should provide, so the addon system can use it for the cmd
+// ClusterAddon describes what functions a cluster addon should provide, so the addon system can use it for the cmd
 type ClusterAddon interface {
 	Name() string
 	Requires() []string
@@ -12,7 +12,7 @@ type ClusterAddon interface {
 	Uninstall()
 }
 
-//ClusterAddonInitializer is a function creating ClusterAddon instances from given parameters
+// ClusterAddonInitializer is a function creating ClusterAddon instances from given parameters
 type ClusterAddonInitializer func(provider clustermanager.ClusterProvider, communicator clustermanager.NodeCommunicator) ClusterAddon
 
 var addonInitializers = make([]ClusterAddonInitializer, 0)
@@ -21,14 +21,14 @@ func addAddon(clusterAddon ClusterAddonInitializer) {
 	addonInitializers = append(addonInitializers, clusterAddon)
 }
 
-//ClusterAddonService provide the addon service
+// ClusterAddonService provide the addon service
 type ClusterAddonService struct {
 	provider         clustermanager.ClusterProvider
 	nodeCommunicator clustermanager.NodeCommunicator
 	addons           []ClusterAddon
 }
 
-//NewClusterAddonService creates an instance of the cluster addon service
+// NewClusterAddonService creates an instance of the cluster addon service
 func NewClusterAddonService(provider clustermanager.ClusterProvider, nodeComm clustermanager.NodeCommunicator) *ClusterAddonService {
 	clusterAddons := []ClusterAddon{}
 	for _, initializer := range addonInitializers {
@@ -37,7 +37,7 @@ func NewClusterAddonService(provider clustermanager.ClusterProvider, nodeComm cl
 	return &ClusterAddonService{provider: provider, nodeCommunicator: nodeComm, addons: clusterAddons}
 }
 
-//AddonExists return true, if an addon with the requested name exists
+// AddonExists return true, if an addon with the requested name exists
 func (addonService *ClusterAddonService) AddonExists(addonName string) bool {
 	for _, addon := range addonService.addons {
 		if addon.Name() == addonName {
@@ -47,7 +47,7 @@ func (addonService *ClusterAddonService) AddonExists(addonName string) bool {
 	return false
 }
 
-//GetAddon returns the ClusterAddon instance given by name, or nil if not found
+// GetAddon returns the ClusterAddon instance given by name, or nil if not found
 func (addonService *ClusterAddonService) GetAddon(addonName string) ClusterAddon {
 	for _, addon := range addonService.addons {
 		if addon.Name() == addonName {
@@ -58,7 +58,7 @@ func (addonService *ClusterAddonService) GetAddon(addonName string) ClusterAddon
 	return nil
 }
 
-//Addons returns a list of all addons
+// Addons returns a list of all addons
 func (addonService *ClusterAddonService) Addons() []ClusterAddon {
 	return addonService.addons
 }

--- a/pkg/addons/util.go
+++ b/pkg/addons/util.go
@@ -2,7 +2,7 @@ package addons
 
 import "log"
 
-//FatalOnError is an helper function used to transfor error to fatal
+// FatalOnError is an helper function used to transfor error to fatal
 func FatalOnError(err error) {
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -10,7 +10,7 @@ import (
 
 const rewriteTpl = `cat /etc/kubernetes/%s | sed -e 's/server: https\(.*\)/server: https:\/\/127.0.0.1:16443/g' > /tmp/cp && mv /tmp/cp /etc/kubernetes/%s`
 
-//Manager is the structure used to mange cluster
+// Manager is the structure used to mange cluster
 type Manager struct {
 	nodes            []Node
 	clusterName      string
@@ -23,7 +23,7 @@ type Manager struct {
 	selfHosted       bool
 }
 
-//NewClusterManager create a new manager for the cluster
+// NewClusterManager create a new manager for the cluster
 func NewClusterManager(provider ClusterProvider, nodeCommunicator NodeCommunicator, eventService EventService, name string, haEnabled bool, isolatedEtcd bool, cloudInitFile string, selfHosted bool) *Manager {
 	manager := &Manager{
 		clusterName:      name,
@@ -40,7 +40,7 @@ func NewClusterManager(provider ClusterProvider, nodeCommunicator NodeCommunicat
 	return manager
 }
 
-//NewClusterManagerFromCluster create a new manager from an existing cluster
+// NewClusterManagerFromCluster create a new manager from an existing cluster
 func NewClusterManagerFromCluster(cluster Cluster, provider ClusterProvider, nodeCommunicator NodeCommunicator, eventService EventService) *Manager {
 	return &Manager{
 		clusterName:      cluster.Name,
@@ -55,7 +55,7 @@ func NewClusterManagerFromCluster(cluster Cluster, provider ClusterProvider, nod
 	}
 }
 
-//Cluster creates a Cluster object for further processing
+// Cluster creates a Cluster object for further processing
 func (manager *Manager) Cluster() Cluster {
 	return Cluster{
 		Name:          manager.clusterName,
@@ -98,7 +98,7 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 	return waitOrError(trueChan, errChan, &numProcs)
 }
 
-//SetupEncryptedNetwork setups an encrypted virtual network using wireguard
+// SetupEncryptedNetwork setups an encrypted virtual network using wireguard
 // modifies the state of manager.Nodes
 func (manager *Manager) SetupEncryptedNetwork() error {
 	var err error
@@ -148,7 +148,7 @@ func (manager *Manager) SetupEncryptedNetwork() error {
 	return nil
 }
 
-//InstallMasters installs the kubernetes control plane to master nodes
+// InstallMasters installs the kubernetes control plane to master nodes
 func (manager *Manager) InstallMasters() error {
 
 	commands := []NodeCommand{
@@ -273,7 +273,7 @@ func (manager *Manager) installMasterStep(node Node, numMaster int, masterNode N
 	trueChan <- true
 }
 
-//InstallEtcdNodes installs the etcd cluster
+// InstallEtcdNodes installs the etcd cluster
 func (manager *Manager) InstallEtcdNodes(nodes []Node) error {
 
 	commands := []NodeCommand{
@@ -316,7 +316,7 @@ func (manager *Manager) InstallEtcdNodes(nodes []Node) error {
 	return waitOrError(trueChan, errChan, &numProcs)
 }
 
-//InstallWorkers installs kubernetes workers to given nodes
+// InstallWorkers installs kubernetes workers to given nodes
 func (manager *Manager) InstallWorkers(nodes []Node) error {
 	node, err := manager.clusterProvider.GetMasterNode()
 	if err != nil {
@@ -367,7 +367,7 @@ func (manager *Manager) InstallWorkers(nodes []Node) error {
 	return waitOrError(trueChan, errChan, &numProcs)
 }
 
-//SetupHA installs the high-availability plane to cluster
+// SetupHA installs the high-availability plane to cluster
 func (manager *Manager) SetupHA() error {
 	// copy pki
 	masterNode, err := manager.clusterProvider.GetMasterNode()
@@ -433,7 +433,7 @@ func (manager *Manager) SetupHA() error {
 	return waitOrError(trueChan, errChan, &numProcs)
 }
 
-//DeployLoadBalancer installs a client based load balancer for the master nodes to given nodes
+// DeployLoadBalancer installs a client based load balancer for the master nodes to given nodes
 func (manager *Manager) DeployLoadBalancer(nodes []Node) error {
 
 	errChan := make(chan error)

--- a/pkg/clustermanager/configs.go
+++ b/pkg/clustermanager/configs.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-//GenerateMasterConfiguration generate the kubernetes config for master
+// GenerateMasterConfiguration generate the kubernetes config for master
 func GenerateMasterConfiguration(masterNode Node, masterNodes, etcdNodes []Node) string {
 	masterConfigTpl := `apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
@@ -34,7 +34,7 @@ apiServerCertSANs:
 	return masterConfig
 }
 
-//GenerateEtcdSystemdService generate configuration file used to manage etcd service on systemd
+// GenerateEtcdSystemdService generate configuration file used to manage etcd service on systemd
 func GenerateEtcdSystemdService(node Node, etcdNodes []Node) string {
 	serviceTpls := `# /etc/systemd/system/etcd.service
 [Unit]

--- a/pkg/clustermanager/interfaces.go
+++ b/pkg/clustermanager/interfaces.go
@@ -1,6 +1,6 @@
 package clustermanager
 
-//NodeCommunicator is the interface used to define a node comunication protocol
+// NodeCommunicator is the interface used to define a node comunication protocol
 type NodeCommunicator interface {
 	RunCmd(node Node, command string) (string, error)
 	WriteFile(node Node, filePath string, content string, executable bool) error
@@ -8,12 +8,12 @@ type NodeCommunicator interface {
 	TransformFileOverNode(source Node, target Node, filePath string, transform func(string) string) error
 }
 
-//EventService is the interface used to manage events
+// EventService is the interface used to manage events
 type EventService interface {
 	AddEvent(eventName string, eventMessage string)
 }
 
-//ClusterProvider is the interface used to declare a cluster provider
+// ClusterProvider is the interface used to declare a cluster provider
 type ClusterProvider interface {
 	SetNodes([]Node)
 	GetAllNodes() []Node

--- a/pkg/clustermanager/types.go
+++ b/pkg/clustermanager/types.go
@@ -1,6 +1,6 @@
 package clustermanager
 
-//Node is the structure used to define a node
+// Node is the structure used to define a node
 type Node struct {
 	Name             string    `json:"name"`
 	Type             string    `json:"type"`
@@ -12,7 +12,7 @@ type Node struct {
 	WireGuardKeyPair WgKeyPair `json:"wire_guard_key_pair"`
 }
 
-//Cluster is the structure used to define a cluster
+// Cluster is the structure used to define a cluster
 type Cluster struct {
 	Name          string `json:"name"`
 	Nodes         []Node `json:"nodes"`
@@ -23,7 +23,7 @@ type Cluster struct {
 	NodeCIDR      string `json:"node_cidr"`
 }
 
-//NodeCommand is the structure used to define acommand to execute on a node
+// NodeCommand is the structure used to define acommand to execute on a node
 type NodeCommand struct {
 	EventName string
 	Command   string

--- a/pkg/clustermanager/wireguard.go
+++ b/pkg/clustermanager/wireguard.go
@@ -10,13 +10,13 @@ import (
 	"golang.org/x/crypto/curve25519"
 )
 
-//WgKeyPair containse key pairs
+// WgKeyPair containse key pairs
 type WgKeyPair struct {
 	Private string `json:"private"`
 	Public  string `json:"public"`
 }
 
-//GenerateWireguardConf generate wireguard configuration file
+// GenerateWireguardConf generate wireguard configuration file
 func GenerateWireguardConf(node Node, nodes []Node) string {
 	var output string
 	// print header block

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xetys/hetzner-kube/pkg/clustermanager"
 )
 
-//Provider contains provider information
+// Provider contains provider information
 type Provider struct {
 	client        *hcloud.Client
 	context       context.Context

--- a/pkg/progress.go
+++ b/pkg/progress.go
@@ -2,7 +2,7 @@ package pkg
 
 import "github.com/gosuri/uiprogress"
 
-//Progress define the progress on command execution
+// Progress define the progress on command execution
 type Progress struct {
 	Name    string
 	Bar     *uiprogress.Bar
@@ -10,7 +10,7 @@ type Progress struct {
 	State   string
 }
 
-//SetText define text to display during progress
+// SetText define text to display during progress
 func (progress *Progress) SetText(text string) {
 	if text != "" {
 		progress.State = text

--- a/pkg/progress_coordinator.go
+++ b/pkg/progress_coordinator.go
@@ -10,19 +10,19 @@ import (
 	"github.com/gosuri/uiprogress/util/strutil"
 )
 
-//CompletedEvent indicate the process completed
+// CompletedEvent indicate the process completed
 const CompletedEvent = "complete!"
 
-//UIProgressCoordinator coortinate display of progress in UI
+// UIProgressCoordinator coortinate display of progress in UI
 type UIProgressCoordinator struct {
 	group      sync.WaitGroup
 	progresses map[string]*Progress
 }
 
-//RenderProgressBars indicate if we need to display progress in UI
+// RenderProgressBars indicate if we need to display progress in UI
 var RenderProgressBars bool
 
-//NewProgressCoordinator create a new progress coordinator UI
+// NewProgressCoordinator create a new progress coordinator UI
 func NewProgressCoordinator() *UIProgressCoordinator {
 	if isUIEnabled() {
 		uiprogress.Start()
@@ -48,7 +48,7 @@ func shortLeftPadRight(s string, padWidth int) string {
 	return strutil.PadRight(s, padWidth, ' ')
 }
 
-//StartProgress start the progress UI
+// StartProgress start the progress UI
 func (c *UIProgressCoordinator) StartProgress(name string, steps int) {
 	progress := &Progress{
 		Bar:     uiprogress.AddBar(steps),
@@ -89,7 +89,7 @@ func (c *UIProgressCoordinator) StartProgress(name string, steps int) {
 	}(progress)
 }
 
-//AddEvent add an new event in the progress UI
+// AddEvent add an new event in the progress UI
 func (c *UIProgressCoordinator) AddEvent(progressName string, eventName string) {
 	if progress, isPresent := c.progresses[progressName]; isPresent {
 		progress.channel <- eventName
@@ -103,7 +103,7 @@ func (c *UIProgressCoordinator) CompleteProgress(nodeName string) {
 	}
 }
 
-//Wait temporary stop the progress UI
+// Wait temporary stop the progress UI
 func (c *UIProgressCoordinator) Wait() {
 	c.group.Wait()
 	if isUIEnabled() {


### PR DESCRIPTION
Remove comments that are not useful from codebase.

 - License header is removed since there is already a license file in the repository root
 - Comments on cobra command are not useful
 - Spacing in documentation are inconsistent