### PR TITLE
Proposal for Cloud-init status check and System Wide Environment Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /hetzner-kube*
 /dist
 /vendor
-
+**.log
 /cmd/test.go

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -83,7 +83,7 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 		go func(node Node) {
 			manager.eventService.AddEvent(node.Name, "install packages")
 			//_, err := manager.nodeCommunicator.RunCmd(node, "wget -cO- https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh | bash -")
-			provisioner := NewNodeProvisioner(node, manager.nodeCommunicator, manager.eventService)
+			provisioner := NewNodeProvisioner(manager.clusterName, node, manager.nodeCommunicator, manager.eventService)
 			err := provisioner.Provision(node, manager.nodeCommunicator, manager.eventService)
 			if err != nil {
 				errChan <- err


### PR DESCRIPTION
This PR related to #246 
Because nature of changes (they pretty small) i did them as single PR, but if required i can split them.
Change 1:
 Idea behind is to let `hetzner_cloud` possibility to ensure that Cloud-init complete its task and only then continue own tasks. 
Why this is important? Because if some one (for example me) trying to install several packages include ansible, Cloud-init can take significantly longer time to do its job and if `apt/yum/whatever packager` involved to this process it can cause race-condition:
1) `hetzner_cloud` fail with error 100, which is not critical but require 2nd run (error why it hangs in original issues #246)
2) 'hetzner_cloud'can block cloud-init from successful run by locking `apt/yum/whatever packager` and cloud-init as result will fail, `.../boot-finished` file will be added, but everything you sent over user-data wont be processed (at least everything what is rely on packagers and things they should install)

Change 2: 
Provide System Wide Environment Variables. At this moment i set 2 of them: 
`HETZNER_KUBE_MASTER` and `HETZNER_KUBE_CLUSTER` (but we can add later more). 
Why they required?
Simple example - we want run ansible, and we need able to determinate difference between clusters to run different tasks for example which is only for `dev` or only for `prod` or maybe even only for masters or non-masters. before it was not possible because we do not have any single idea about cluster identity or about node role in this cluster. Sure we can split hostname into blocks, but global environment variables better , because `hetzner_cloud` already knows who is who.

Both changes tested with several clusters.

output of export:
```
k8s-dev-master-01:~# export
declare -x HETZNER_KUBE_CLUSTER="k8s-dev"
declare -x HETZNER_KUBE_MASTER="true"
```
```
k8s-dev-worker-02:~# export
declare -x HETZNER_KUBE_CLUSTER="k8s-dev"
declare -x HETZNER_KUBE_MASTER="false"
```