### PR TITLE
[Require more tests] Bump Docker and Kubelet to eliminate CVE-2019-5736

### DIFF
--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -336,7 +336,7 @@ func (manager *Manager) InstallWorkers(nodes []Node) error {
 	if err != nil {
 		return err
 	}
-	joinCommand = fmt.Sprintf("%s --cri-socket /var/run/docker/containerd/docker-containerd.sock", strings.TrimRight(joinCommand, "\n"))
+	//joinCommand = fmt.Sprintf("%s --cri-socket unix:///var/run/containerd/containerd.sock", strings.TrimRight(joinCommand, "\n"))
 
 	errChan := make(chan error)
 	trueChan := make(chan bool)

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -336,7 +336,6 @@ func (manager *Manager) InstallWorkers(nodes []Node) error {
 	if err != nil {
 		return err
 	}
-	//joinCommand = fmt.Sprintf("%s --cri-socket unix:///var/run/containerd/containerd.sock", strings.TrimRight(joinCommand, "\n"))
 
 	errChan := make(chan error)
 	trueChan := make(chan bool)

--- a/pkg/clustermanager/configs.go
+++ b/pkg/clustermanager/configs.go
@@ -24,7 +24,7 @@ apiEndpoint:
   advertiseAddress: %s
   bindPort: 6443
 nodeRegistration:
-  criSocket: /var/run/docker/containerd/docker-containerd.sock
+  # criSocket: /var/run/containerd/containerd.sock
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master

--- a/pkg/clustermanager/configs.go
+++ b/pkg/clustermanager/configs.go
@@ -24,7 +24,6 @@ apiEndpoint:
   advertiseAddress: %s
   bindPort: 6443
 nodeRegistration:
-  # criSocket: /var/run/containerd/containerd.sock
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master

--- a/pkg/clustermanager/configs_test.go
+++ b/pkg/clustermanager/configs_test.go
@@ -26,7 +26,7 @@ apiEndpoint:
   advertiseAddress: 10.0.0.1
   bindPort: 6443
 nodeRegistration:
-  criSocket: /var/run/docker/containerd/docker-containerd.sock
+  # criSocket: /var/run/containerd/containerd.sock
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
@@ -56,7 +56,7 @@ apiEndpoint:
   advertiseAddress: 10.0.0.1
   bindPort: 6443
 nodeRegistration:
-  criSocket: /var/run/docker/containerd/docker-containerd.sock
+  # criSocket: /var/run/containerd/containerd.sock
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master

--- a/pkg/clustermanager/configs_test.go
+++ b/pkg/clustermanager/configs_test.go
@@ -26,7 +26,6 @@ apiEndpoint:
   advertiseAddress: 10.0.0.1
   bindPort: 6443
 nodeRegistration:
-  # criSocket: /var/run/containerd/containerd.sock
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
@@ -56,7 +55,6 @@ apiEndpoint:
   advertiseAddress: 10.0.0.1
   bindPort: 6443
 nodeRegistration:
-  # criSocket: /var/run/containerd/containerd.sock
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -11,7 +11,7 @@ import (
 const maxErrors = 3
 
 // K8sVersion is the version that will be used to install kubernetes
-var K8sVersion = flag.String("k8s-version", "1.13.2-00", "The version of the k8s debian packages that will be used during provisioning")
+var K8sVersion = flag.String("k8s-version", "1.13.3-00", "The version of the k8s debian packages that will be used during provisioning")
 
 // NodeProvisioner provisions all basic packages to install docker, kubernetes and wireguard
 type NodeProvisioner struct {
@@ -206,7 +206,7 @@ func (provisioner *NodeProvisioner) prepareDocker() error {
 	// docker-ce
 	aptPreferencesDocker := `
 Package: docker-ce
-Pin: version 18.06.0~ce~3-0~ubuntu
+Pin: version 18.09.2~3-0~ubuntu-bionic
 Pin-Priority: 1000
 	`
 	err := provisioner.communicator.WriteFile(provisioner.node, "/etc/apt/preferences.d/docker-ce", aptPreferencesDocker, false)


### PR DESCRIPTION
* Kubernetes 1.13.3
* Docker 18.09.2
* Containerd.io 1.2.2-3
* Kubelete Containers runtime to vanila Docker

TODO:
 * [ ] Fix deprecated config parameters 
 * [ ] Follow logs for possible errors

P.S. as bonus, now [ctop](https://github.com/bcicen/ctop) also able to get stats :)

Successfully deployed:
```
kubectl get nodes
NAME                STATUS   ROLES    AGE     VERSION
k8s-dev-master-01   Ready    master   9m36s   v1.13.3
k8s-dev-master-02   Ready    master   8m19s   v1.13.3
k8s-dev-master-03   Ready    master   8m12s   v1.13.3
k8s-dev-worker-01   Ready    <none>   6m26s   v1.13.3
```
```
kubectl get pods -n kube-system
NAME                                        READY   STATUS    RESTARTS   AGE
canal-26rth                                 3/3     Running   4          8m56s
canal-h4s7f                                 3/3     Running   3          8m49s
canal-xhg6c                                 3/3     Running   2          7m3s
canal-ztntb                                 3/3     Running   6          9m53s
coredns-86c58d9df4-h9v4n                    1/1     Running   1          9m53s
coredns-86c58d9df4-rsxz9                    1/1     Running   2          9m53s
kube-apiserver-k8s-dev-master-01            1/1     Running   1          8m51s
kube-apiserver-k8s-dev-master-02            1/1     Running   1          6m25s
kube-apiserver-k8s-dev-master-03            1/1     Running   1          6m38s
kube-controller-manager-k8s-dev-master-01   1/1     Running   2          8m50s
kube-controller-manager-k8s-dev-master-02   1/1     Running   2          6m26s
kube-controller-manager-k8s-dev-master-03   1/1     Running   2          7m21s
kube-proxy-7brgr                            1/1     Running   2          7m3s
kube-proxy-mdsp6                            1/1     Running   1          8m14s
kube-proxy-tbldc                            1/1     Running   2          8m10s
kube-proxy-zhwmt                            1/1     Running   1          8m17s
kube-scheduler-k8s-dev-master-01            1/1     Running   1          9m13s
kube-scheduler-k8s-dev-master-02            1/1     Running   2          6m16s
kube-scheduler-k8s-dev-master-03            1/1     Running   1          6m27s
```
