### PR TITLE
Update hcloud-go to v1.12.0

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -145,6 +145,7 @@ func (app *AppConfig) SwitchContextByName(name string) error {
 
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(ctx.Token),
+		hcloud.WithApplication("hetzner-kube", version),
 	}
 
 	app.Client = hcloud.NewClient(opts...)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gosuri/uilive v0.0.0-20170323041506-ac356e6e42cd // indirect
 	github.com/gosuri/uiprogress v0.0.0-20170224063937-d0567a9d84a1
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
-	github.com/hetznercloud/hcloud-go v1.8.0
+	github.com/hetznercloud/hcloud-go v1.12.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/magiconair/properties v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/gosuri/uiprogress v0.0.0-20170224063937-d0567a9d84a1 h1:4iPLwzjiWGBQn
 github.com/gosuri/uiprogress v0.0.0-20170224063937-d0567a9d84a1/go.mod h1:C1RTYn4Sc7iEyf6j8ft5dyoZ4212h8G1ol9QQluh5+0=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce h1:xdsDDbiBDQTKASoGEZ+pEmF1OnWuu8AQ9I8iNbHNeno=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hetznercloud/hcloud-go v1.8.0 h1:gqTrlBXnIDQZkXn4L1suqNzmLJWAJLum5Vn9j2EwJBU=
-github.com/hetznercloud/hcloud-go v1.8.0/go.mod h1:g5pff0YNAZywQaivY/CmhUYFVp7oP0nu3MiODC2W4Hw=
+github.com/hetznercloud/hcloud-go v1.12.0 h1:ugZO8a8ADekqSWi7xWlcs6pxr4QE0tw5VnyjXcL5n28=
+github.com/hetznercloud/hcloud-go v1.12.0/go.mod h1:g5pff0YNAZywQaivY/CmhUYFVp7oP0nu3MiODC2W4Hw=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=


### PR DESCRIPTION
This PR updates the underlying hcloud-go version from 1.8.0 to 1.12.0 and set the hcloud-go application name to hetzner-kube. With this change, we can track which tool created how many servers on our side. 