### PR TITLE
Fix CSI issue and upgrade to kubernetes 1.14.0

### DIFF
--- a/pkg/clustermanager/configs.go
+++ b/pkg/clustermanager/configs.go
@@ -9,11 +9,15 @@ import (
 func GenerateMasterConfiguration(masterNode Node, masterNodes []Node, etcdNodes []Node) string {
 	masterConfigTpl := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
+kubernetesVersion: stable
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
   dnsDomain: "cluster.local"
 apiServer:
+  featureGates:
+    CSINodeInfo: true
+    CSIDriverRegistry: true
   certSANs:
     - 127.0.0.1
     - %s

--- a/pkg/clustermanager/configs_test.go
+++ b/pkg/clustermanager/configs_test.go
@@ -9,11 +9,15 @@ import (
 func TestGenerateMasterConfiguration(t *testing.T) {
 	expectedConf := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
+kubernetesVersion: stable
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
   dnsDomain: "cluster.local"
 apiServer:
+  featureGates:
+    CSINodeInfo: true
+    CSIDriverRegistry: true
   certSANs:
     - 127.0.0.1
     - 1.1.1.1
@@ -40,11 +44,15 @@ featureGates:
 
 	expectedConfWithEtcd := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
+kubernetesVersion: stable
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
   dnsDomain: "cluster.local"
 apiServer:
+  featureGates:
+    CSINodeInfo: true
+    CSIDriverRegistry: true
   certSANs:
     - 127.0.0.1
     - 1.1.1.1

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -248,7 +248,6 @@ func (provisioner *NodeProvisioner) updateAndInstall() error {
 // Last step because otherwise we need create script to check if variables already set and replaces them
 // As soon as it is last step we are ok to set them in basic way
 func (provisioner *NodeProvisioner) setSystemWideEnvironment() error {
-
 	provisioner.eventService.AddEvent(provisioner.node.Name, "set environment variables")
 	var err error
 

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -11,7 +11,7 @@ import (
 const maxErrors = 3
 
 // K8sVersion is the version that will be used to install kubernetes
-var K8sVersion = flag.String("k8s-version", "1.13.4-00", "The version of the k8s debian packages that will be used during provisioning")
+var K8sVersion = flag.String("k8s-version", "1.14.0-00", "The version of the k8s debian packages that will be used during provisioning")
 
 // NodeProvisioner provisions all basic packages to install docker, kubernetes and wireguard
 type NodeProvisioner struct {


### PR DESCRIPTION
This PR will update to kubernetes 1.14.0 and fix issue on CSI.

Actually tested with a new cluster, than create a secret with hetzner token:
```
cat >secret.yaml <<EOF
---
kind: Secret
apiVersion: v1
metadata:
  namespace: kube-system
  name: hcloud-csi
data:
  token: {ADD_TOKEN_BASE64_ENCODED_HERE}
EOF
```
and deploy all the required stuff:
```
kubectl apply -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csidriver.yaml
kubectl apply -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csinodeinfo.yaml
kubectl apply -f https://gist.githubusercontent.com/mavimo/399d9f783a59653bac71c8ddbf886757/raw/bc9ff2bcc6c38fea27f2586ce5da0cfa2a6e004e/hetzner-csi.yaml
```
at the end create a new pod using the PV, eg:
```
cat >test-csi.yaml <<EOF
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: hcloud-volumes
---
kind: Pod
apiVersion: v1
metadata:
  name: my-csi-app
spec:
  containers:
    - name: my-frontend
      image: busybox
      volumeMounts:
      - mountPath: "/data"
        name: my-csi-volume
      command: [ "sleep", "1000000" ]
  volumes:
    - name: my-csi-volume
      persistentVolumeClaim:
        claimName: csi-pvc
EOF;

```

and deploy it:
```
kubectl apply -f test-csi.yaml
```

that's work without issue on logs (I inspected with `journalctl -u kubelet` on master and worker nodes).