### PR TITLE
randomize the order of datacenters

### DIFF
--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"strings"
-	"math/rand"
 	"time"
 
 	"github.com/go-kit/kit/log/term"

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"os"
 	"strings"
+	"math/rand"
+	"time"
 
 	"github.com/go-kit/kit/log/term"
 	"github.com/gosuri/uiprogress"
@@ -74,6 +76,10 @@ func (provider *Provider) CreateNodes(suffix string, template clustermanager.Nod
 	serverOptsTemplate.SSHKeys = append(serverOptsTemplate.SSHKeys, sshKey)
 
 	datacentersCount := len(datacenters)
+
+	//shuffle datacenters to make it more random
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(datacentersCount, func(i, j int) { datacenters[i], datacenters[j] = datacenters[j], datacenters[i] })
 
 	var nodes []clustermanager.Node
 	for i := 1; i <= count; i++ {


### PR DESCRIPTION
When adding new (worker) nodes, the nodes are always created in the same data centers based on the provided order (default [fsn1-dc8,nbg1-dc3,hel1-dc2,fsn1-dc14]).
And while that works fine upon initial cluster creation, evenly distributing nodes across data centers it does not work when creating nodes after the fact. They're always created in the same data center.

This PR fixes that by randomizing the provided data center list while still making sure the nodes are evenly distributed.