### PR TITLE
Indent JSON when writing it to file

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,7 +49,7 @@ func NewAppConfig(debug bool) AppConfig {
 // WriteCurrentConfig write the configuration to file
 func (config HetznerConfig) WriteCurrentConfig() {
 	configFileName := filepath.Join(DefaultConfigPath, "config.json")
-	configJSON, err := json.Marshal(&config)
+	configJSON, err := json.MarshalIndent(&config, "", "    ")
 
 	if err == nil {
 		err = ioutil.WriteFile(configFileName, configJSON, 0666)


### PR DESCRIPTION
This will make the output of config.json looks nicer and more human-readable.

I like to edit or view the JSON file from time to time. By having it nicely indented this will be easier.