### PR TITLE
Bump Kubernetes from 1.16.2 to 1.16.4

### DIFF
--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -11,7 +11,7 @@ import (
 const maxErrors = 3
 
 // K8sVersion is the version that will be used to install kubernetes
-var K8sVersion = flag.String("k8s-version", "1.16.2-00", "The version of the k8s debian packages that will be used during provisioning")
+var K8sVersion = flag.String("k8s-version", "1.16.4-00", "The version of the k8s debian packages that will be used during provisioning")
 
 // NodeProvisioner provisions all basic packages to install docker, kubernetes and wireguard
 type NodeProvisioner struct {


### PR DESCRIPTION
This bumps Kubernetes from 1.16.2 to the latest 1.16 release (1.16.4)