### PR TITLE
Make sure Kubernetes version is the same

### DIFF
--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -93,7 +93,7 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 		go func(node Node) {
 			manager.eventService.AddEvent(node.Name, "install packages")
 			//_, err := manager.nodeCommunicator.RunCmd(node, "wget -cO- https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh | bash -")
-			provisioner := NewNodeProvisioner(manager.clusterName, node, manager.nodeCommunicator, manager.eventService, manager.Cluster().KubernetesVersion)
+			provisioner := NewNodeProvisioner(node, manager)
 			err := provisioner.Provision(node, manager.nodeCommunicator, manager.eventService)
 			if err != nil {
 				errChan <- err

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -68,12 +68,13 @@ func NewClusterManagerFromCluster(cluster Cluster, provider ClusterProvider, nod
 // Cluster creates a Cluster object for further processing
 func (manager *Manager) Cluster() Cluster {
 	return Cluster{
-		Name:          manager.clusterName,
-		Nodes:         manager.nodes,
-		HaEnabled:     manager.haEnabled,
-		IsolatedEtcd:  manager.isolatedEtcd,
-		CloudInitFile: manager.cloudInitFile,
-		NodeCIDR:      manager.clusterProvider.GetNodeCidr(),
+		Name:              manager.clusterName,
+		Nodes:             manager.nodes,
+		HaEnabled:         manager.haEnabled,
+		IsolatedEtcd:      manager.isolatedEtcd,
+		CloudInitFile:     manager.cloudInitFile,
+		NodeCIDR:          manager.clusterProvider.GetNodeCidr(),
+		KubernetesVersion: "1.16.4",
 	}
 }
 
@@ -243,7 +244,7 @@ func (manager *Manager) installMasterStep(node Node, numMaster int, masterNode N
 		}
 	}
 	masterNodes := manager.clusterProvider.GetMasterNodes()
-	masterConfig := GenerateMasterConfiguration(node, masterNodes, etcdNodes)
+	masterConfig := GenerateMasterConfiguration(node, masterNodes, etcdNodes, manager.Cluster().KubernetesVersion)
 	if err := manager.nodeCommunicator.WriteFile(node, "/root/master-config.yaml", masterConfig, AllRead); err != nil {
 		errChan <- err
 	}

--- a/pkg/clustermanager/cluster.go
+++ b/pkg/clustermanager/cluster.go
@@ -93,7 +93,7 @@ func (manager *Manager) ProvisionNodes(nodes []Node) error {
 		go func(node Node) {
 			manager.eventService.AddEvent(node.Name, "install packages")
 			//_, err := manager.nodeCommunicator.RunCmd(node, "wget -cO- https://raw.githubusercontent.com/xetys/hetzner-kube/master/install-docker-kubeadm.sh | bash -")
-			provisioner := NewNodeProvisioner(manager.clusterName, node, manager.nodeCommunicator, manager.eventService)
+			provisioner := NewNodeProvisioner(manager.clusterName, node, manager.nodeCommunicator, manager.eventService, manager.Cluster().KubernetesVersion)
 			err := provisioner.Provision(node, manager.nodeCommunicator, manager.eventService)
 			if err != nil {
 				errChan <- err

--- a/pkg/clustermanager/configs.go
+++ b/pkg/clustermanager/configs.go
@@ -6,10 +6,10 @@ import (
 )
 
 // GenerateMasterConfiguration generate the kubernetes config for master
-func GenerateMasterConfiguration(masterNode Node, masterNodes []Node, etcdNodes []Node) string {
+func GenerateMasterConfiguration(masterNode Node, masterNodes []Node, etcdNodes []Node, kubernetesVersion string) string {
 	masterConfigTpl := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: stable
+kubernetesVersion: v%s
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
@@ -58,6 +58,7 @@ featureGates:
 
 	masterConfig := fmt.Sprintf(
 		masterConfigTpl,
+		kubernetesVersion,
 		masterNodesIps,
 		etcdConfig,
 		masterNode.PrivateIPAddress,

--- a/pkg/clustermanager/configs_test.go
+++ b/pkg/clustermanager/configs_test.go
@@ -9,7 +9,7 @@ import (
 func TestGenerateMasterConfiguration(t *testing.T) {
 	expectedConf := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: stable
+kubernetesVersion: v1.16.4
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
@@ -45,7 +45,7 @@ featureGates:
 
 	expectedConfWithEtcd := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: stable
+kubernetesVersion: v.16.4
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
@@ -88,13 +88,15 @@ featureGates:
 		{Name: "node2", IPAddress: "1.1.1.2", PrivateIPAddress: "10.0.0.2"},
 	}
 
-	noEtcdConf := GenerateMasterConfiguration(nodes[0], nodes, nil)
+	kubernetesVersion := "1.16.4"
+
+	noEtcdConf := GenerateMasterConfiguration(nodes[0], nodes, nil, kubernetesVersion)
 
 	if noEtcdConf != expectedConf {
 		t.Errorf("master config without etcd does not match to expected.\n%s\n", diff.LineDiff(noEtcdConf, expectedConf))
 	}
 
-	etcdConf := GenerateMasterConfiguration(nodes[0], nodes, nodes)
+	etcdConf := GenerateMasterConfiguration(nodes[0], nodes, nodes, kubernetesVersion)
 
 	if etcdConf != expectedConfWithEtcd {
 		t.Errorf("master config with etcd does not match to expected.\n%s\n", diff.LineDiff(etcdConf, expectedConfWithEtcd))

--- a/pkg/clustermanager/configs_test.go
+++ b/pkg/clustermanager/configs_test.go
@@ -45,7 +45,7 @@ featureGates:
 
 	expectedConfWithEtcd := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: v.16.4
+kubernetesVersion: v1.16.4
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -1,7 +1,6 @@
 package clustermanager
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,24 +9,23 @@ import (
 
 const maxErrors = 3
 
-// K8sVersion is the version that will be used to install kubernetes
-var K8sVersion = flag.String("k8s-version", "1.16.2-00", "The version of the k8s debian packages that will be used during provisioning")
-
 // NodeProvisioner provisions all basic packages to install docker, kubernetes and wireguard
 type NodeProvisioner struct {
-	clusterName  string
-	node         Node
-	communicator NodeCommunicator
-	eventService EventService
+	clusterName       string
+	node              Node
+	communicator      NodeCommunicator
+	eventService      EventService
+	kubernetesVersion string
 }
 
 // NewNodeProvisioner creates a NodeProvisioner instance
-func NewNodeProvisioner(clusterName string, node Node, communicator NodeCommunicator, eventService EventService) *NodeProvisioner {
+func NewNodeProvisioner(clusterName string, node Node, communicator NodeCommunicator, eventService EventService, kubernetesVersion string) *NodeProvisioner {
 	return &NodeProvisioner{
-		clusterName:  clusterName,
-		node:         node,
-		communicator: communicator,
-		eventService: eventService,
+		clusterName:       clusterName,
+		node:              node,
+		communicator:      communicator,
+		eventService:      eventService,
+		kubernetesVersion: kubernetesVersion,
 	}
 }
 
@@ -235,8 +233,8 @@ func (provisioner *NodeProvisioner) updateAndInstall() error {
 	}
 
 	provisioner.eventService.AddEvent(provisioner.node.Name, "installing packages")
-	command := fmt.Sprintf("apt-get install -y docker-ce kubelet=%s kubeadm=%s kubectl=%s kubernetes-cni=0.7.5-00 wireguard linux-headers-$(uname -r) linux-headers-virtual",
-		*K8sVersion, *K8sVersion, *K8sVersion)
+	command := fmt.Sprintf("apt-get install -y docker-ce kubelet=%s-00 kubeadm=%s-00 kubectl=%s-00 kubernetes-cni=0.7.5-00 wireguard linux-headers-$(uname -r) linux-headers-virtual",
+		provisioner.kubernetesVersion, provisioner.kubernetesVersion, provisioner.kubernetesVersion)
 	_, err = provisioner.communicator.RunCmd(provisioner.node, command)
 	if err != nil {
 		return err

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -19,13 +19,13 @@ type NodeProvisioner struct {
 }
 
 // NewNodeProvisioner creates a NodeProvisioner instance
-func NewNodeProvisioner(clusterName string, node Node, communicator NodeCommunicator, eventService EventService, kubernetesVersion string) *NodeProvisioner {
+func NewNodeProvisioner(node Node, manager *Manager) *NodeProvisioner {
 	return &NodeProvisioner{
-		clusterName:       clusterName,
+		clusterName:       manager.clusterName,
 		node:              node,
-		communicator:      communicator,
-		eventService:      eventService,
-		kubernetesVersion: kubernetesVersion,
+		communicator:      manager.nodeCommunicator,
+		eventService:      manager.eventService,
+		kubernetesVersion: manager.Cluster().KubernetesVersion,
 	}
 }
 

--- a/pkg/clustermanager/types.go
+++ b/pkg/clustermanager/types.go
@@ -14,12 +14,13 @@ type Node struct {
 
 // Cluster is the structure used to define a cluster
 type Cluster struct {
-	Name          string `json:"name"`
-	Nodes         []Node `json:"nodes"`
-	HaEnabled     bool   `json:"ha_enabled"`
-	IsolatedEtcd  bool   `json:"isolated_etcd"`
-	CloudInitFile string `json:"cloud_init_file"`
-	NodeCIDR      string `json:"node_cidr"`
+	Name              string `json:"name"`
+	Nodes             []Node `json:"nodes"`
+	HaEnabled         bool   `json:"ha_enabled"`
+	IsolatedEtcd      bool   `json:"isolated_etcd"`
+	CloudInitFile     string `json:"cloud_init_file"`
+	NodeCIDR          string `json:"node_cidr"`
+	KubernetesVersion string `json:"kubernetes_version"`
 }
 
 // NodeCommand is the structure used to define acommand to execute on a node


### PR DESCRIPTION
This makes sure that the Kubernetes version is the same everywhere. This is a quick POC at the moment.

@xetys what do you think about this idea? Should we also make the Kubernetes version configurable by a CLI flag?

This fixes #306 
