### PR TITLE
Bump hcloud-cloud-controller-manager version

### DIFF
--- a/pkg/addons/addon_hcloud_controller_manager.go
+++ b/pkg/addons/addon_hcloud_controller_manager.go
@@ -70,7 +70,7 @@ Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
 	FatalOnError(err)
 	_, err = addon.communicator.RunCmd(*addon.masterNode, fmt.Sprintf("kubectl -n kube-system create secret generic hcloud --from-literal=token=%s", addon.provider.Token()))
 	FatalOnError(err)
-	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.0.yaml")
+	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.1.yaml")
 	FatalOnError(err)
 	// This is needed cause there is a bug inside the hcloud-cloud-controller-manager deployment spec.
 	// The env-variable "network" is not marked as optional but is also not needed for the deployment.
@@ -82,7 +82,7 @@ Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
 
 // Uninstall performs all steps to remove the addon
 func (addon *HCloudControllerManagerAddon) Uninstall() {
-	_, err := addon.communicator.RunCmd(*addon.masterNode, "kubectl delete -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.0.yaml")
+	_, err := addon.communicator.RunCmd(*addon.masterNode, "kubectl delete -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.1.yaml")
 	FatalOnError(err)
 	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl -n kube-system delete secret hcloud")
 	FatalOnError(err)

--- a/pkg/addons/addon_hcloud_controller_manager.go
+++ b/pkg/addons/addon_hcloud_controller_manager.go
@@ -70,7 +70,7 @@ Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
 	FatalOnError(err)
 	_, err = addon.communicator.RunCmd(*addon.masterNode, fmt.Sprintf("kubectl -n kube-system create secret generic hcloud --from-literal=token=%s", addon.provider.Token()))
 	FatalOnError(err)
-	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.1.yaml")
+	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl apply -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.5.1/deploy/v1.5.1.yaml")
 	FatalOnError(err)
 	// This is needed cause there is a bug inside the hcloud-cloud-controller-manager deployment spec.
 	// The env-variable "network" is not marked as optional but is also not needed for the deployment.
@@ -82,7 +82,7 @@ Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
 
 // Uninstall performs all steps to remove the addon
 func (addon *HCloudControllerManagerAddon) Uninstall() {
-	_, err := addon.communicator.RunCmd(*addon.masterNode, "kubectl delete -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/v1.5.1.yaml")
+	_, err := addon.communicator.RunCmd(*addon.masterNode, "kubectl delete -f  https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.5.1/deploy/v1.5.1.yaml")
 	FatalOnError(err)
 	_, err = addon.communicator.RunCmd(*addon.masterNode, "kubectl -n kube-system delete secret hcloud")
 	FatalOnError(err)


### PR DESCRIPTION
The old v1.5.0 manifest is no longer available, therefore need to change the version to the current release.