### PR TITLE
Fix hwe 1804 kernel

### DIFF
--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -178,10 +178,10 @@ func (provisioner *NodeProvisioner) preparePackages() error {
 	}
 
 	// wireguard
-	_, err = provisioner.communicator.RunCmd(provisioner.node, "add-apt-repository ppa:wireguard/wireguard -y")
-	if err != nil {
-		return err
-	}
+	// _, err = provisioner.communicator.RunCmd(provisioner.node, "add-apt-repository ppa:wireguard/wireguard -y")
+	// if err != nil {
+	//   return err
+	// }
 
 	return nil
 }
@@ -233,7 +233,7 @@ func (provisioner *NodeProvisioner) updateAndInstall() error {
 	}
 
 	provisioner.eventService.AddEvent(provisioner.node.Name, "installing packages")
-	command := fmt.Sprintf("apt-get install -y docker-ce kubelet=%s-00 kubeadm=%s-00 kubectl=%s-00 kubernetes-cni=0.7.5-00 wireguard linux-headers-$(uname -r) linux-headers-virtual",
+	command := fmt.Sprintf("apt-get install -y docker-ce kubelet=%s-00 kubeadm=%s-00 kubectl=%s-00 kubernetes-cni=0.7.5-00 linux-headers-$(uname -r) linux-headers-virtual",
 		provisioner.kubernetesVersion, provisioner.kubernetesVersion, provisioner.kubernetesVersion)
 	_, err = provisioner.communicator.RunCmd(provisioner.node, command)
 	if err != nil {

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -177,12 +177,6 @@ func (provisioner *NodeProvisioner) preparePackages() error {
 		return err
 	}
 
-	// wireguard
-	// _, err = provisioner.communicator.RunCmd(provisioner.node, "add-apt-repository ppa:wireguard/wireguard -y")
-	// if err != nil {
-	//   return err
-	// }
-
 	return nil
 }
 func (provisioner *NodeProvisioner) prepareKubernetes() error {

--- a/pkg/clustermanager/provision_node.go
+++ b/pkg/clustermanager/provision_node.go
@@ -227,7 +227,7 @@ func (provisioner *NodeProvisioner) updateAndInstall() error {
 	}
 
 	provisioner.eventService.AddEvent(provisioner.node.Name, "installing packages")
-	command := fmt.Sprintf("apt-get install -y docker-ce kubelet=%s-00 kubeadm=%s-00 kubectl=%s-00 kubernetes-cni=0.7.5-00 linux-headers-$(uname -r) linux-headers-virtual",
+	command := fmt.Sprintf("apt-get install -y --install-recommends linux-generic-hwe-18.04 && apt-get install -y docker-ce kubelet=%s-00 kubeadm=%s-00 kubectl=%s-00 kubernetes-cni=0.7.5-00 linux-headers-$(uname -r) linux-headers-virtual wireguard-tools wireguard wireguard-dkms && modprobe wireguard",
 		provisioner.kubernetesVersion, provisioner.kubernetesVersion, provisioner.kubernetesVersion)
 	_, err = provisioner.communicator.RunCmd(provisioner.node, command)
 	if err != nil {


### PR DESCRIPTION
The **HWE Kernel Patch** is **missing** in https://github.com/xetys/hetzner-kube/pull/339 and therefore **not working for me**.

I **incorporated** the lessons from the **cloud-config workaround** mentioned in https://github.com/xetys/hetzner-kube/issues/329#issuecomment-651561356 **into** the **source code** of my latest fix.

So with my fix, you can just do a minimal: `hetzner-kube cluster create --name <name> --ssh-key <key>` to successfully provision your cluster incl. wg VPN Networking.