### PR TITLE
Upgrade to Kubernetes 1.19.2, Ubuntu 20.04 and Calico 3.16.x, fix printing newlines for context subcommands

### DIFF
--- a/cmd/cluster_add_external_worker.go
+++ b/cmd/cluster_add_external_worker.go
@@ -19,7 +19,7 @@ var clusterAddExternalWorkerCmd = &cobra.Command{
 	Long: `This lets you add an external server to your cluster.
 
 An external server must meet the following requirements:
-	- ubuntu 16.04
+	- ubuntu 20.04
 	- a unique hostname, that doesn't collide with an existing node name
 	- accessible with the same SSH key as used for the cluster`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -67,13 +67,13 @@ An external server must meet the following requirements:
 			}
 		}
 
-		// check ubuntu 16.04
+		// check ubuntu 20.04
 		issue, err := AppConf.SSHClient.RunCmd(externalNode, "cat /etc/issue | xargs")
 		if err != nil {
 			return err
 		}
-		if !strings.Contains(issue, "Ubuntu 16.04") {
-			return errors.New("target server has no Ubuntu 16.04 installed")
+		if !strings.Contains(issue, "Ubuntu 20.04") {
+			return errors.New("target server has no Ubuntu 20.04 installed")
 		}
 
 		return nil

--- a/cmd/context_add.go
+++ b/cmd/context_add.go
@@ -55,7 +55,7 @@ var addCmd = &cobra.Command{
 		AppConf.Config.ActiveContextName = name
 		AppConf.Config.WriteCurrentConfig()
 		AppConf.CurrentContext = context
-		fmt.Printf("added context '%s'", name)
+		fmt.Printf("added context '%s'\n", name)
 	},
 }
 

--- a/cmd/context_use.go
+++ b/cmd/context_use.go
@@ -19,7 +19,7 @@ var useCmd = &cobra.Command{
 		FatalOnError(err)
 
 		AppConf.Config.WriteCurrentConfig()
-		fmt.Printf("switched to context '%s'", contextName)
+		fmt.Printf("switched to context '%s'\n", contextName)
 	},
 }
 

--- a/pkg/clustermanager/configs_test.go
+++ b/pkg/clustermanager/configs_test.go
@@ -9,7 +9,7 @@ import (
 func TestGenerateMasterConfiguration(t *testing.T) {
 	expectedConf := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: v1.16.4
+kubernetesVersion: v1.19.2
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
@@ -45,7 +45,7 @@ featureGates:
 
 	expectedConfWithEtcd := `apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: v1.16.4
+kubernetesVersion: v1.19.2
 networking:
   serviceSubnet: "10.96.0.0/12"
   podSubnet: "10.244.0.0/16"
@@ -88,7 +88,7 @@ featureGates:
 		{Name: "node2", IPAddress: "1.1.1.2", PrivateIPAddress: "10.0.0.2"},
 	}
 
-	kubernetesVersion := "1.16.4"
+	kubernetesVersion := "1.19.2"
 
 	noEtcdConf := GenerateMasterConfiguration(nodes[0], nodes, nil, kubernetesVersion)
 

--- a/pkg/hetzner/hetzner_provider.go
+++ b/pkg/hetzner/hetzner_provider.go
@@ -61,7 +61,7 @@ func (provider *Provider) CreateNodes(suffix string, template clustermanager.Nod
 			Name: template.Type,
 		},
 		Image: &hcloud.Image{
-			Name: "ubuntu-18.04",
+			Name: "ubuntu-20.04",
 		},
 	}
 


### PR DESCRIPTION
Worked and is stable for several weeks on 2 new clusters of mine. Didn't run an integration test. Here's the command I used to create the clusters:

```
hetzner-kube cluster create --name "${cluster_name}" --ssh-key "${USER}@$(hostname -s)" --datacenters fsn1-dc14 --master-server-type cx11-ceph --worker-count 2 --worker-server-type cx11-ceph
```